### PR TITLE
Development

### DIFF
--- a/AZALDevToolsServer/AZALDevToolsTestConsoleApp.NetFramework/Program.cs
+++ b/AZALDevToolsServer/AZALDevToolsTestConsoleApp.NetFramework/Program.cs
@@ -65,7 +65,7 @@ namespace AZALDevToolsTestConsoleApp.NetFramework
             ALProject project = workspace.Projects[0];
 
             PageInformationProvider pageInformationProvider = new PageInformationProvider();
-            PageInformation pageInformation = pageInformationProvider.GetPageDetails(project, "MyPageCard", true, true);
+            PageInformation pageInformation = pageInformationProvider.GetPageDetails(project, "MyPageCard", true, true, true);
 
             /*
             XmlPortInformationProvider xmlPortInformationProvider = new XmlPortInformationProvider();

--- a/AZALDevToolsServer/AZALDevToolsTestConsoleApp.NetFramework/Program.cs
+++ b/AZALDevToolsServer/AZALDevToolsTestConsoleApp.NetFramework/Program.cs
@@ -65,7 +65,7 @@ namespace AZALDevToolsTestConsoleApp.NetFramework
             ALProject project = workspace.Projects[0];
 
             PageInformationProvider pageInformationProvider = new PageInformationProvider();
-            PageInformation pageInformation = pageInformationProvider.GetPageDetails(project, "MyPageCard", true, true, true);
+            PageInformation pageInformation = pageInformationProvider.GetPageDetails(project, "MyPageCard", true, true, true, null);
 
             /*
             XmlPortInformationProvider xmlPortInformationProvider = new XmlPortInformationProvider();

--- a/AZALDevToolsServer/AZALDevToolsTestConsoleApp.NetFramework/Program.cs
+++ b/AZALDevToolsServer/AZALDevToolsTestConsoleApp.NetFramework/Program.cs
@@ -4,6 +4,7 @@ using AnZwDev.ALTools.ALSymbols;
 using AnZwDev.ALTools.ALSymbols.SymbolReaders;
 using AnZwDev.ALTools.CodeAnalysis;
 using AnZwDev.ALTools.CodeTransformations;
+using AnZwDev.ALTools.Core;
 using AnZwDev.ALTools.Server;
 using AnZwDev.ALTools.Workspace;
 using AnZwDev.ALTools.Workspace.SymbolsInformation;
@@ -42,7 +43,7 @@ namespace AZALDevToolsTestConsoleApp.NetFramework
 
             
             filePath = "C:\\Projects\\Sandboxes\\al-test-projects\\SmallBC18\\Pag50104.MyPrefixMyPageCard.al";
-            string content = System.IO.File.ReadAllText(filePath);
+            string content = FileUtils.SafeReadAllText(filePath);
             Dictionary<string, string> pm = new Dictionary<string, string>();
             pm.Add("sourceFilePath", filePath);
             string projectPath = "C:\\Projects\\Sandboxes\\al-test-projects\\SmallBC18";

--- a/AZALDevToolsServer/AZALDevToolsTestConsoleApp/Program.cs
+++ b/AZALDevToolsServer/AZALDevToolsTestConsoleApp/Program.cs
@@ -85,6 +85,12 @@ namespace AZALDevToolsTestConsoleApp
             pm.Add("removeLocalVariables", "true");
             pm.Add("removeLocalMethodParameters", "true");
 
+            pm.Add("dependencyName0", "Microsoft - System");
+            pm.Add("dependencyName1", "Microsoft - Application");
+            pm.Add("dependencyName2", "Microsoft - System Application");
+            pm.Add("dependencyName3", "Microsoft - Base Application");
+
+
             //WorkspaceCommandResult o = host.ALDevToolsServer.WorkspaceCommandsManager.RunCommand("removeWith", content, projectPath, null, pm);
             //WorkspaceCommandResult o = host.ALDevToolsServer.WorkspaceCommandsManager.RunCommand("addAllObjectsPermissions", content, projectPath, null, pm);
             //WorkspaceCommandResult o = host.ALDevToolsServer.WorkspaceCommandsManager.RunCommand("fixIdentifiersCase", content, projects[0], null, pm);
@@ -93,15 +99,22 @@ namespace AZALDevToolsTestConsoleApp
             //WorkspaceCommandResult o = host.ALDevToolsServer.WorkspaceCommandsManager.RunCommand("addParentheses", content, projects[0], filePath, null, pm);
             //WorkspaceCommandResult o = host.ALDevToolsServer.WorkspaceCommandsManager.RunCommand("sortVariables", content, projects[0], filePath, null, pm);
             //WorkspaceCommandResult o = host.ALDevToolsServer.WorkspaceCommandsManager.RunCommand("removeBeginEnd", content, projects[0], filePath, null, pm);
-            WorkspaceCommandResult o = host.ALDevToolsServer.WorkspaceCommandsManager.RunCommand("addToolTips", content, projects[0], filePath, null, pm);
+            //WorkspaceCommandResult o = host.ALDevToolsServer.WorkspaceCommandsManager.RunCommand("addToolTips", content, projects[0], filePath, null, pm);
+            WorkspaceCommandResult o = host.ALDevToolsServer.WorkspaceCommandsManager.RunCommand("refreshToolTips", content, projects[0], filePath, null, pm);
 
             ALProject project = host.ALDevToolsServer.Workspace.Projects[0];
+
+            
+            PageInformationProvider pageInformationProvider = new PageInformationProvider();
+            List<string> toolTipsList = pageInformationProvider.GetPageFieldAvailableToolTips(project, "Page", "MyTestPage", "", "Rec.\"No.\"");
+
+            PageInformation pageInformation = pageInformationProvider.GetPageDetails(project, "wqefewf", true, true, true, null);
 
             ObjectIdInformationProvider objectIdInformationProvider = new();
             long id = objectIdInformationProvider.GetNextObjectId(project, "Page");
 
             TableInformationProvider tableInformationProvider = new();
-            List<TableFieldInformaton> fields = tableInformationProvider.GetTableFields(project, "Purchase Line", false, false, true, true, true, false);
+            List<TableFieldInformaton> fields = tableInformationProvider.GetTableFields(project, "Purchase Line", false, false, true, true, true, false, null);
             List<TableFieldInformaton> fields2 = fields.Where(p => (p.Name.StartsWith("Description"))).ToList();
 
             ReportInformationProvider reportInformationProvider = new();

--- a/AZALDevToolsServer/AZALDevToolsTestConsoleApp/Program.cs
+++ b/AZALDevToolsServer/AZALDevToolsTestConsoleApp/Program.cs
@@ -73,7 +73,8 @@ namespace AZALDevToolsTestConsoleApp
             //filePath = "C:\\Projects\\Sandboxes\\al-test-projects\\BC184TestProject\\FunctionsTest.al";
             //filePath = "C:\\Projects\\Sandboxes\\al-test-projects\\BC184TestProject\\Pag50103.MyTestPage2.al";
             //filePath = "C:\\Projects\\Sandboxes\\al-test-projects\\BC184TestProject\\Rep50100.MyReport.al";
-            filePath = "C:\\Projects\\Sandboxes\\al-test-projects\\BC184TestProject\\MyTestCU.al";
+            //filePath = "C:\\Projects\\Sandboxes\\al-test-projects\\BC184TestProject\\MyTestCU.al";
+            filePath = "C:\\Projects\\Sandboxes\\al-test-projects\\BC184TestProject\\Pag50105.MyTestPage.al";
 
             string content = FileUtils.SafeReadAllText(filePath);
             Dictionary<string, string> pm = new();
@@ -91,8 +92,8 @@ namespace AZALDevToolsTestConsoleApp
             //WorkspaceCommandResult o = host.ALDevToolsServer.WorkspaceCommandsManager.RunCommand("convertObjectIdsToNames", content, projects[0], null, pm);
             //WorkspaceCommandResult o = host.ALDevToolsServer.WorkspaceCommandsManager.RunCommand("addParentheses", content, projects[0], filePath, null, pm);
             //WorkspaceCommandResult o = host.ALDevToolsServer.WorkspaceCommandsManager.RunCommand("sortVariables", content, projects[0], filePath, null, pm);
-            
-            WorkspaceCommandResult o = host.ALDevToolsServer.WorkspaceCommandsManager.RunCommand("removeBeginEnd", content, projects[0], filePath, null, pm);
+            //WorkspaceCommandResult o = host.ALDevToolsServer.WorkspaceCommandsManager.RunCommand("removeBeginEnd", content, projects[0], filePath, null, pm);
+            WorkspaceCommandResult o = host.ALDevToolsServer.WorkspaceCommandsManager.RunCommand("addToolTips", content, projects[0], filePath, null, pm);
 
             ALProject project = host.ALDevToolsServer.Workspace.Projects[0];
 
@@ -100,7 +101,7 @@ namespace AZALDevToolsTestConsoleApp
             long id = objectIdInformationProvider.GetNextObjectId(project, "Page");
 
             TableInformationProvider tableInformationProvider = new();
-            List<TableFieldInformaton> fields = tableInformationProvider.GetTableFields(project, "Purchase Line", false, false, true, true, true);
+            List<TableFieldInformaton> fields = tableInformationProvider.GetTableFields(project, "Purchase Line", false, false, true, true, true, false);
             List<TableFieldInformaton> fields2 = fields.Where(p => (p.Name.StartsWith("Description"))).ToList();
 
             ReportInformationProvider reportInformationProvider = new();

--- a/AZALDevToolsServer/AZALDevToolsTestConsoleApp/Program.cs
+++ b/AZALDevToolsServer/AZALDevToolsTestConsoleApp/Program.cs
@@ -89,8 +89,9 @@ namespace AZALDevToolsTestConsoleApp
             //WorkspaceCommandResult o = host.ALDevToolsServer.WorkspaceCommandsManager.RunCommand("removeUnusedVariables", content, projects[0], filePath, null, pm);
             //WorkspaceCommandResult o = host.ALDevToolsServer.WorkspaceCommandsManager.RunCommand("convertObjectIdsToNames", content, projects[0], null, pm);
             //WorkspaceCommandResult o = host.ALDevToolsServer.WorkspaceCommandsManager.RunCommand("addParentheses", content, projects[0], filePath, null, pm);
+            //WorkspaceCommandResult o = host.ALDevToolsServer.WorkspaceCommandsManager.RunCommand("sortVariables", content, projects[0], filePath, null, pm);
             
-            WorkspaceCommandResult o = host.ALDevToolsServer.WorkspaceCommandsManager.RunCommand("sortVariables", content, projects[0], filePath, null, pm);
+            WorkspaceCommandResult o = host.ALDevToolsServer.WorkspaceCommandsManager.RunCommand("removeBeginEnd", content, projects[0], filePath, null, pm);
 
             ALProject project = host.ALDevToolsServer.Workspace.Projects[0];
 

--- a/AZALDevToolsServer/AZALDevToolsTestConsoleApp/Program.cs
+++ b/AZALDevToolsServer/AZALDevToolsTestConsoleApp/Program.cs
@@ -7,6 +7,7 @@ using AnZwDev.ALTools.ALSymbols;
 using AnZwDev.ALTools.ALSymbols.SymbolReaders;
 using AnZwDev.ALTools.CodeAnalysis;
 using AnZwDev.ALTools.CodeTransformations;
+using AnZwDev.ALTools.Core;
 using AnZwDev.ALTools.Server;
 using AnZwDev.ALTools.Workspace;
 using AnZwDev.ALTools.Workspace.SymbolsInformation;
@@ -74,7 +75,7 @@ namespace AZALDevToolsTestConsoleApp
             //filePath = "C:\\Projects\\Sandboxes\\al-test-projects\\BC184TestProject\\Rep50100.MyReport.al";
             filePath = "C:\\Projects\\Sandboxes\\al-test-projects\\BC184TestProject\\MyTestCU.al";
 
-            string content = System.IO.File.ReadAllText(filePath);
+            string content = FileUtils.SafeReadAllText(filePath);
             Dictionary<string, string> pm = new();
             pm.Add("sourceFilePath", filePath);
             pm.Add("skipFormatting", "true");

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools.Server/ALDevToolsServerHost.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools.Server/ALDevToolsServerHost.cs
@@ -77,6 +77,7 @@ namespace AnZwDev.ALTools.Server
             this.Dispatcher.RegisterRequestHandler(new GetQueryDataItemDetailsRequestHandler(this.ALDevToolsServer, this));
             this.Dispatcher.RegisterRequestHandler(new GetPermissionSetsRequestHandler(this.ALDevToolsServer, this));
             this.Dispatcher.RegisterRequestHandler(new GetReportDetailsRequestHandler(this.ALDevToolsServer, this));
+            this.Dispatcher.RegisterRequestHandler(new GetDependenciesListRequestHandler(this.ALDevToolsServer, this));
 
             //next available object id
             this.Dispatcher.RegisterRequestHandler(new GetNextObjectIdRequestHandler(this.ALDevToolsServer, this));

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools.Server/ALDevToolsServerHost.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools.Server/ALDevToolsServerHost.cs
@@ -72,6 +72,7 @@ namespace AnZwDev.ALTools.Server
             this.Dispatcher.RegisterRequestHandler(new GetXmlPortsListRequestHandler(this.ALDevToolsServer, this));
             this.Dispatcher.RegisterRequestHandler(new GetPagesListRequestHandler(this.ALDevToolsServer, this));
             this.Dispatcher.RegisterRequestHandler(new GetPageDetailsRequestHandler(this.ALDevToolsServer, this));
+            this.Dispatcher.RegisterRequestHandler(new GetPageFieldsAvailableToolTipsRequestHandler(this.ALDevToolsServer, this));
             this.Dispatcher.RegisterRequestHandler(new GetXmlPortTableElementDetailsRequestHandler(this.ALDevToolsServer, this));
             this.Dispatcher.RegisterRequestHandler(new GetReportDataItemDetailsRequestHandler(this.ALDevToolsServer, this));
             this.Dispatcher.RegisterRequestHandler(new GetQueryDataItemDetailsRequestHandler(this.ALDevToolsServer, this));

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools.Server/Contracts/SymbolsInformation/GetDependenciesListRequest.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools.Server/Contracts/SymbolsInformation/GetDependenciesListRequest.cs
@@ -4,10 +4,8 @@ using System.Text;
 
 namespace AnZwDev.ALTools.Server.Contracts.SymbolsInformation
 {
-    public class GetPageDetailsRequest : GetTableBasedSymbolDetailsRequest
+    public class GetDependenciesListRequest
     {
-
-        public bool getToolTips { get; set; }
-
+        public string path { get; set; }
     }
 }

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools.Server/Contracts/SymbolsInformation/GetDependenciesListResponse.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools.Server/Contracts/SymbolsInformation/GetDependenciesListResponse.cs
@@ -4,10 +4,8 @@ using System.Text;
 
 namespace AnZwDev.ALTools.Server.Contracts.SymbolsInformation
 {
-    public class GetPageDetailsRequest : GetTableBasedSymbolDetailsRequest
+    public class GetDependenciesListResponse
     {
-
-        public bool getToolTips { get; set; }
-
+        public List<string> dependencies { get; set; }
     }
 }

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools.Server/Contracts/SymbolsInformation/GetPageDetailsRequest.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools.Server/Contracts/SymbolsInformation/GetPageDetailsRequest.cs
@@ -8,6 +8,7 @@ namespace AnZwDev.ALTools.Server.Contracts.SymbolsInformation
     {
 
         public bool getToolTips { get; set; }
+        public string[] toolTipsSourceDependencies { get; set; }
 
     }
 }

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools.Server/Contracts/SymbolsInformation/GetPageFieldAvailableToolTipsRequest.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools.Server/Contracts/SymbolsInformation/GetPageFieldAvailableToolTipsRequest.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace AnZwDev.ALTools.Server.Contracts.SymbolsInformation
+{
+    public class GetPageFieldAvailableToolTipsRequest
+    {
+        public string path { get; set; }
+        public string objectType { get; set; }
+        public string objectName { get; set; }
+        public string sourceTable { get; set; }
+        public string fieldExpression { get; set; }
+
+    }
+}

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools.Server/Contracts/SymbolsInformation/GetPageFieldAvailableToolTipsResponse.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools.Server/Contracts/SymbolsInformation/GetPageFieldAvailableToolTipsResponse.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace AnZwDev.ALTools.Server.Contracts.SymbolsInformation
+{
+    public class GetPageFieldAvailableToolTipsResponse
+    {
+        public List<string> toolTips { get; set; }
+    }
+}

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools.Server/Contracts/SymbolsInformation/GetTableFieldsListRequest.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools.Server/Contracts/SymbolsInformation/GetTableFieldsListRequest.cs
@@ -13,6 +13,7 @@ namespace AnZwDev.ALTools.Server.Contracts.SymbolsInformation
         public bool includeNormal { get; set; }
         public bool includeFlowFields { get; set; }
         public bool includeFlowFilters { get; set; }
+        public bool includeToolTips { get; set; }
 
     }
 }

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools.Server/Contracts/SymbolsInformation/GetTableFieldsListRequest.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools.Server/Contracts/SymbolsInformation/GetTableFieldsListRequest.cs
@@ -14,6 +14,7 @@ namespace AnZwDev.ALTools.Server.Contracts.SymbolsInformation
         public bool includeFlowFields { get; set; }
         public bool includeFlowFilters { get; set; }
         public bool includeToolTips { get; set; }
+        public string[] toolTipsSourceDependencies { get; set; }
 
     }
 }

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools.Server/Handlers/SymbolsInformation/GetDependenciesListRequestHandler.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools.Server/Handlers/SymbolsInformation/GetDependenciesListRequestHandler.cs
@@ -28,9 +28,10 @@ namespace AnZwDev.ALTools.Server.Handlers.SymbolsInformation
                 if (project != null)
                 {
                     response.dependencies = new List<string>();
-                    for (int i = 0; i < project.AllSymbols.AllSymbolReferences.Count; i++)
+                    for (int i = 0; i < project.Dependencies.Count; i++)
                     {
-                        response.dependencies.Add(project.AllSymbols.AllSymbolReferences[i].GetNameWithPublisher());
+                        if (project.Dependencies[i].Symbols != null)
+                            response.dependencies.Add(project.Dependencies[i].Symbols.GetNameWithPublisher());
                     }
                 }
             }

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools.Server/Handlers/SymbolsInformation/GetDependenciesListRequestHandler.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools.Server/Handlers/SymbolsInformation/GetDependenciesListRequestHandler.cs
@@ -1,0 +1,48 @@
+﻿using AnZwDev.ALTools.ALSymbolReferences;
+using AnZwDev.ALTools.Extensions;
+using AnZwDev.ALTools.Server.Contracts.SymbolsInformation;
+using AnZwDev.ALTools.Workspace;
+using AnZwDev.VSCodeLangServer.Protocol.MessageProtocol;
+using AnZwDev.VSCodeLangServer.Protocol.Server;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace AnZwDev.ALTools.Server.Handlers.SymbolsInformation
+{
+    public class GetDependenciesListRequestHandler : BaseALRequestHandler<GetDependenciesListRequest, GetDependenciesListResponse>
+    {
+        public GetDependenciesListRequestHandler(ALDevToolsServer server, LanguageServerHost languageServerHost) : base(server, languageServerHost, "al/getdependencieslist")
+        {
+        }
+
+#pragma warning disable 1998
+        protected override async Task<GetDependenciesListResponse> HandleMessage(GetDependenciesListRequest parameters, RequestContext<GetDependenciesListResponse> context)
+        {
+            GetDependenciesListResponse response = new GetDependenciesListResponse();
+
+            try
+            {
+                ALProject project = this.Server.Workspace.FindProject(parameters.path, true);
+                if (project != null)
+                {
+                    response.dependencies = new List<string>();
+                    for (int i = 0; i < project.AllSymbols.AllSymbolReferences.Count; i++)
+                    {
+                        response.dependencies.Add(project.AllSymbols.AllSymbolReferences[i].GetNameWithPublisher());
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                this.LogError(e);
+            }
+
+            return response;
+
+        }
+#pragma warning restore 1998
+
+    }
+}

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools.Server/Handlers/SymbolsInformation/GetPageDetailsRequestHandler.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools.Server/Handlers/SymbolsInformation/GetPageDetailsRequestHandler.cs
@@ -29,7 +29,7 @@ namespace AnZwDev.ALTools.Server.Handlers.SymbolsInformation
                 if (project != null)
                 {
                     PageInformationProvider provider = new PageInformationProvider();
-                    response.symbol = provider.GetPageDetails(project, parameters.name, parameters.getExistingFields, parameters.getAvailableFields);
+                    response.symbol = provider.GetPageDetails(project, parameters.name, parameters.getExistingFields, parameters.getAvailableFields, parameters.getToolTips);
                     if (response.symbol != null)
                         response.symbol.Sort();
                 }

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools.Server/Handlers/SymbolsInformation/GetPageDetailsRequestHandler.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools.Server/Handlers/SymbolsInformation/GetPageDetailsRequestHandler.cs
@@ -29,7 +29,7 @@ namespace AnZwDev.ALTools.Server.Handlers.SymbolsInformation
                 if (project != null)
                 {
                     PageInformationProvider provider = new PageInformationProvider();
-                    response.symbol = provider.GetPageDetails(project, parameters.name, parameters.getExistingFields, parameters.getAvailableFields, parameters.getToolTips);
+                    response.symbol = provider.GetPageDetails(project, parameters.name, parameters.getExistingFields, parameters.getAvailableFields, parameters.getToolTips, parameters.toolTipsSourceDependencies);
                     if (response.symbol != null)
                         response.symbol.Sort();
                 }

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools.Server/Handlers/SymbolsInformation/GetPageFieldsAvailableToolTipsRequestHandler.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools.Server/Handlers/SymbolsInformation/GetPageFieldsAvailableToolTipsRequestHandler.cs
@@ -1,0 +1,35 @@
+﻿using AnZwDev.ALTools.Server.Contracts.SymbolsInformation;
+using AnZwDev.ALTools.Workspace;
+using AnZwDev.ALTools.Workspace.SymbolsInformation;
+using AnZwDev.VSCodeLangServer.Protocol.Server;
+using AnZwDev.VSCodeLangServer.Protocol.MessageProtocol;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace AnZwDev.ALTools.Server.Handlers.SymbolsInformation
+{
+    internal class GetPageFieldsAvailableToolTipsRequestHandler : BaseALRequestHandler<GetPageFieldAvailableToolTipsRequest, GetPageFieldAvailableToolTipsResponse>
+    {
+        public GetPageFieldsAvailableToolTipsRequestHandler(ALDevToolsServer server, LanguageServerHost languageServerHost) : base(server, languageServerHost, "al/getpagefieldtooltips")
+        {
+        }
+
+#pragma warning disable 1998
+        protected override async Task<GetPageFieldAvailableToolTipsResponse> HandleMessage(GetPageFieldAvailableToolTipsRequest parameters, RequestContext<GetPageFieldAvailableToolTipsResponse> context)
+        {
+            GetPageFieldAvailableToolTipsResponse response = new GetPageFieldAvailableToolTipsResponse();
+
+            ALProject project = this.Server.Workspace.FindProject(parameters.path, true);
+            if (project != null)
+            {
+                PageInformationProvider provider = new PageInformationProvider();
+                response.toolTips = provider.GetPageFieldAvailableToolTips(project, parameters.objectType, parameters.objectName, parameters.sourceTable, parameters.fieldExpression);
+            }
+
+            return response;
+        }
+#pragma warning restore 1998
+    }
+}

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools.Server/Handlers/SymbolsInformation/GetTableFieldsListRequestHandler.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools.Server/Handlers/SymbolsInformation/GetTableFieldsListRequestHandler.cs
@@ -26,7 +26,7 @@ namespace AnZwDev.ALTools.Server.Handlers.SymbolsInformation
             if (project != null)
             {
                 TableInformationProvider provider = new TableInformationProvider();
-                response.symbols = provider.GetTableFields(project, parameters.table, parameters.includeDisabled, parameters.includeObsolete, parameters.includeNormal, parameters.includeFlowFields, parameters.includeFlowFilters);
+                response.symbols = provider.GetTableFields(project, parameters.table, parameters.includeDisabled, parameters.includeObsolete, parameters.includeNormal, parameters.includeFlowFields, parameters.includeFlowFilters, parameters.includeToolTips);
                 response.symbols.Sort(new SymbolInformationComparer());
             }
 

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools.Server/Handlers/SymbolsInformation/GetTableFieldsListRequestHandler.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools.Server/Handlers/SymbolsInformation/GetTableFieldsListRequestHandler.cs
@@ -26,7 +26,7 @@ namespace AnZwDev.ALTools.Server.Handlers.SymbolsInformation
             if (project != null)
             {
                 TableInformationProvider provider = new TableInformationProvider();
-                response.symbols = provider.GetTableFields(project, parameters.table, parameters.includeDisabled, parameters.includeObsolete, parameters.includeNormal, parameters.includeFlowFields, parameters.includeFlowFilters, parameters.includeToolTips);
+                response.symbols = provider.GetTableFields(project, parameters.table, parameters.includeDisabled, parameters.includeObsolete, parameters.includeNormal, parameters.includeFlowFields, parameters.includeFlowFilters, parameters.includeToolTips, parameters.toolTipsSourceDependencies);
                 response.symbols.Sort(new SymbolInformationComparer());
             }
 

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools.Server/Shared.AnZwDev.ALTools.Server.projitems
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools.Server/Shared.AnZwDev.ALTools.Server.projitems
@@ -33,6 +33,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)Contracts\GetFullSyntaxTreeResponse.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Contracts\GetLibrarySymbolLocationRequest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Contracts\GetLibrarySymbolLocationResponse.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Contracts\SymbolsInformation\GetDependenciesListRequest.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Contracts\SymbolsInformation\GetDependenciesListResponse.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Contracts\SymbolsInformation\GetInterfaceMethodsListRequest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Contracts\SymbolsInformation\GetInterfaceMethodsListResponse.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Contracts\SymbolsInformation\GetNextObjectIdRequest.cs" />
@@ -121,6 +123,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Handlers\ProjectSymbolsRequestHandler.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Handlers\ShutdownRequestHandler.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Handlers\SymbolsInformation\GetCodeunitsListRequestHandler.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Handlers\SymbolsInformation\GetDependenciesListRequestHandler.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Handlers\SymbolsInformation\GetEnumsListRequestHandler.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Handlers\SymbolsInformation\GetInterfaceMethodsListRequestHandler.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Handlers\SymbolsInformation\GetInterfacesListRequestHandler.cs" />

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools.Server/Shared.AnZwDev.ALTools.Server.projitems
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools.Server/Shared.AnZwDev.ALTools.Server.projitems
@@ -63,6 +63,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)Contracts\SymbolsInformation\GetObjectsListResponse.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Contracts\SymbolsInformation\GetPageDetailsRequest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Contracts\SymbolsInformation\GetPageDetailsResponse.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Contracts\SymbolsInformation\GetPageFieldAvailableToolTipsRequest.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Contracts\SymbolsInformation\GetPageFieldAvailableToolTipsResponse.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Contracts\SymbolsInformation\GetPagesListRequest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Contracts\SymbolsInformation\GetPagesListResponse.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Contracts\SymbolsInformation\GetPermissionSetsRequest.cs" />
@@ -130,6 +132,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Handlers\SymbolsInformation\GetNextObjectIdRequestHandler.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Handlers\SymbolsInformation\GetObjectsListRequestHandler.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Handlers\SymbolsInformation\GetPageDetailsRequestHandler.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Handlers\SymbolsInformation\GetPageFieldsAvailableToolTipsRequestHandler.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Handlers\SymbolsInformation\GetPagesListRequestHandler.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Handlers\SymbolsInformation\GetPermissionSetsRequestHandler.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Handlers\SymbolsInformation\GetQueriesListRequestHandler.cs" />

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/ALSymbolReferences/ALAppElementsCollection.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/ALSymbolReferences/ALAppElementsCollection.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/ALSymbolReferences/ALAppEnumExtension.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/ALSymbolReferences/ALAppEnumExtension.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 namespace AnZwDev.ALTools.ALSymbolReferences
 {
-    public class ALAppEnumExtension : ALAppEnum
+    public class ALAppEnumExtension : ALAppEnum, IALAppObjectExtension
     {
 
         public string TargetObject { get; set; }
@@ -28,5 +28,9 @@ namespace AnZwDev.ALTools.ALSymbolReferences
             return ALSymbolKind.EnumExtensionType;
         }
 
+        public string GetTargetObjectName()
+        {
+            return this.TargetObject;
+        }
     }
 }

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/ALSymbolReferences/ALAppObjectsCollection.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/ALSymbolReferences/ALAppObjectsCollection.cs
@@ -28,6 +28,14 @@ namespace AnZwDev.ALTools.ALSymbolReferences
             }
         }
 
+        public IEnumerable<string> GetNamesEnumerable()
+        {
+            for (int i = 0; i < this.Count; i++)
+            {
+                yield return this[i].Name;
+            }
+        }
+
         protected override T FindElement(T element)
         {
             return this.Where(p => (p.Id == element.Id)).FirstOrDefault();

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/ALSymbolReferences/ALAppPageControl.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/ALSymbolReferences/ALAppPageControl.cs
@@ -10,7 +10,8 @@ namespace AnZwDev.ALTools.ALSymbolReferences
     public class ALAppPageControl : ALAppElementWithName
     {
 
-        public string Expression { get; set; }
+
+        //public string Expression { get; set; }
         public ALAppPageControlKind Kind { get; set; }
         public ALAppTypeDefinition TypeDefinition { get; set; }
         public ALAppElementsCollection<ALAppPageControl> Controls { get; set; }
@@ -37,6 +38,32 @@ namespace AnZwDev.ALTools.ALSymbolReferences
             this.Controls?.AddToALSymbol(symbol);
             base.AddChildALSymbols(symbol);
         }
+
+        public string GetSourceExpression()
+        {
+            if (this.Properties != null)
+                return this.Properties.GetProperty("SourceExpression")?.Value;
+            return null;
+        }
+       
+        public void SetSourceExpression(string value)
+        {
+            if (this.Properties == null)
+                this.Properties = new ALAppPropertiesCollection();
+            this.Properties.GetOrCreateProperty("SourceExpression").Value = value;
+        }
+
+        public string GetSourceExpressionWithoutRec()
+        {
+            string expression = this.GetSourceExpression();
+            ALMemberAccessExpression memberAccessExpression = ALSyntaxHelper.DecodeMemberAccessExpression(expression);
+            if (String.IsNullOrWhiteSpace(memberAccessExpression.Name))
+                return memberAccessExpression.Expression;
+            else if (memberAccessExpression.Name.Equals("rec", StringComparison.CurrentCultureIgnoreCase))
+                return memberAccessExpression.Expression;
+            return null;
+        }
+
 
     }
 }

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/ALSymbolReferences/ALAppPageExtension.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/ALSymbolReferences/ALAppPageExtension.cs
@@ -7,7 +7,7 @@ using AnZwDev.ALTools.ALSymbols;
 
 namespace AnZwDev.ALTools.ALSymbolReferences
 {
-    public class ALAppPageExtension : ALAppObject
+    public class ALAppPageExtension : ALAppObject, IALAppObjectExtension
     {
 
         public string TargetObject { get; set; }
@@ -38,5 +38,9 @@ namespace AnZwDev.ALTools.ALSymbolReferences
             base.AddChildALSymbols(symbol);
         }
 
+        public string GetTargetObjectName()
+        {
+            return this.TargetObject;
+        }
     }
 }

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/ALSymbolReferences/ALAppPermissionSetExtension.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/ALSymbolReferences/ALAppPermissionSetExtension.cs
@@ -5,7 +5,7 @@ using System.Text;
 
 namespace AnZwDev.ALTools.ALSymbolReferences
 {
-    public class ALAppPermissionSetExtension : ALAppObject
+    public class ALAppPermissionSetExtension : ALAppObject, IALAppObjectExtension
     {
 
         public string TargetObject { get; set; }
@@ -19,5 +19,9 @@ namespace AnZwDev.ALTools.ALSymbolReferences
             return ALSymbolKind.PermissionSetExtension;
         }
 
+        public string GetTargetObjectName()
+        {
+            return this.TargetObject;
+        }
     }
 }

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/ALSymbolReferences/ALAppPropertiesCollection.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/ALSymbolReferences/ALAppPropertiesCollection.cs
@@ -31,5 +31,17 @@ namespace AnZwDev.ALTools.ALSymbolReferences
             return null;
         }
 
+        public ALAppProperty GetOrCreateProperty(string name)
+        {
+            ALAppProperty property = this.GetProperty(name);
+            if (property == null)
+            {
+                property = new ALAppProperty(name, null);
+                this.Add(property);
+            }
+            return property;
+        }
+
+
     }
 }

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/ALSymbolReferences/ALAppReportExtension.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/ALSymbolReferences/ALAppReportExtension.cs
@@ -5,7 +5,7 @@ using System.Text;
 
 namespace AnZwDev.ALTools.ALSymbolReferences
 {
-    public class ALAppReportExtension : ALAppObject
+    public class ALAppReportExtension : ALAppObject, IALAppObjectExtension
     {
 
         public string Target { get; set; }
@@ -91,5 +91,9 @@ namespace AnZwDev.ALTools.ALSymbolReferences
             symbol.AddChildSymbol(columnsSymbol);
         }
 
+        public string GetTargetObjectName()
+        {
+            return this.Target;
+        }
     }
 }

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/ALSymbolReferences/ALAppSymbolReference.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/ALSymbolReferences/ALAppSymbolReference.cs
@@ -564,5 +564,11 @@ namespace AnZwDev.ALTools.ALSymbolReferences
 
         #endregion
 
+        public string GetNameWithPublisher()
+        {
+            return this.Publisher.NotNull() + " - " + this.Name.NotNull();
+        }
+
+
     }
 }

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/ALSymbolReferences/ALAppTableExtension.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/ALSymbolReferences/ALAppTableExtension.cs
@@ -7,7 +7,7 @@ using AnZwDev.ALTools.ALSymbols;
 
 namespace AnZwDev.ALTools.ALSymbolReferences
 {
-    public class ALAppTableExtension : ALAppTable
+    public class ALAppTableExtension : ALAppTable, IALAppObjectExtension
     {
 
         public string TargetObject { get; set; }
@@ -29,5 +29,9 @@ namespace AnZwDev.ALTools.ALSymbolReferences
             return ALSymbolKind.TableExtensionObject;
         }
 
+        public string GetTargetObjectName()
+        {
+            return this.TargetObject;
+        }
     }
 }

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/ALSymbolReferences/Compiler/ALSymbolReferenceCompiler.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/ALSymbolReferences/Compiler/ALSymbolReferenceCompiler.cs
@@ -310,7 +310,7 @@ namespace AnZwDev.ALTools.ALSymbolReferences.Compiler
         private void ProcessPageField(ALAppPageControl control, PageFieldSyntax node)
         {
             if (node.Expression != null)
-                control.Expression = ALSyntaxHelper.DecodeName(node.Expression.ToString());
+                control.SetSourceExpression(node.Expression.ToString());
         }
 
         private void ProcessPageGroup(ALAppPageControl control, ControlGroupBaseSyntax node)

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/ALSymbolReferences/IALAppObjectExtension.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/ALSymbolReferences/IALAppObjectExtension.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace AnZwDev.ALTools.ALSymbolReferences
+{
+    public interface IALAppObjectExtension
+    {
+
+        string GetTargetObjectName();
+
+    }
+}

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/ALSymbolReferences/MergedReferences/ALAppObjectWithExtensions.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/ALSymbolReferences/MergedReferences/ALAppObjectWithExtensions.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace AnZwDev.ALTools.ALSymbolReferences.MergedReferences
+{
+    public class ALAppObjectWithExtensions<OT, ET> where OT: ALAppObject where ET : ALAppObject, IALAppObjectExtension
+    {
+
+        public OT ALAppObject { get; set; }
+        public List<ET> ALAppObjectExtensions { get; set; }
+
+        public ALAppObjectWithExtensions() : this(null)
+        {
+        }
+
+        public ALAppObjectWithExtensions(OT alAppObject)
+        {
+            this.ALAppObject = alAppObject;
+            this.ALAppObjectExtensions = null;
+        }
+
+        public void AddExtension(ET alAppObjectExtension)
+        {
+            if (this.ALAppObjectExtensions == null)
+                this.ALAppObjectExtensions= new List<ET>();
+            this.ALAppObjectExtensions.Add(alAppObjectExtension);
+        }
+
+    }
+}

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/ALSymbolReferences/MergedReferences/MergedALAppObjectExtensionsCollection.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/ALSymbolReferences/MergedReferences/MergedALAppObjectExtensionsCollection.cs
@@ -5,7 +5,7 @@ using System.Text;
 
 namespace AnZwDev.ALTools.ALSymbolReferences.MergedReferences
 {
-    public class MergedALAppObjectExtensionsCollection<T> : MergedALAppObjectsCollection<T> where T : ALAppObject
+    public class MergedALAppObjectExtensionsCollection<T> : MergedALAppObjectsCollection<T> where T : ALAppObject, IALAppObjectExtension
     {
 
         public MergedALAppObjectExtensionsCollection(IReadOnlyList<ALAppSymbolReference> allSymbols, ALSymbolKind alSymbolKind, Func<ALAppSymbolReference, IList<T>> getALAppObjectsCollection) : base(allSymbols, alSymbolKind, getALAppObjectsCollection)
@@ -23,12 +23,21 @@ namespace AnZwDev.ALTools.ALSymbolReferences.MergedReferences
             {
                 IList<T> objectsList = this.GetALAppObjectsCollection(this.AllSymbolReferences[objListIdx]);
                 if (objectsList != null)
-                    for (int objIdx = 0; objIdx < objectsList.Count; objIdx++)
-                        if ((objectsList[objIdx] != null) && (this.ExtendsObject(objectsList[objIdx], baseObjectName)))
-                            yield return objectsList[objIdx];
+                {
+                    T objectExtension = this.FindFirstExtension(objectsList, baseObjectName);
+                    if (objectExtension != null)
+                        yield return objectExtension;
+                }
             }
         }
 
+        private T FindFirstExtension(IList<T> objectsList, string baseObjectName)
+        {
+            for (int objIdx = 0; objIdx < objectsList.Count; objIdx++)
+                if ((objectsList[objIdx] != null) && (this.ExtendsObject(objectsList[objIdx], baseObjectName)))
+                    return objectsList[objIdx];
+            return null;
+        }
 
     }
 }

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/ALSymbolReferences/MergedReferences/MergedALAppObjectsCollection.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/ALSymbolReferences/MergedReferences/MergedALAppObjectsCollection.cs
@@ -23,13 +23,21 @@ namespace AnZwDev.ALTools.ALSymbolReferences.MergedReferences
 
         public IEnumerable<T> GetObjects()
         {
-            for (int objListIdx=0; objListIdx < this.AllSymbolReferences.Count; objListIdx++)
+            return this.GetObjects(null);
+        }
+
+        public IEnumerable<T> GetObjects(HashSet<string> dependenciesNames)
+        {
+            for (int objListIdx = 0; objListIdx < this.AllSymbolReferences.Count; objListIdx++)
             {
-                IList<T> objectsList = this.GetALAppObjectsCollection(this.AllSymbolReferences[objListIdx]);
-                if (objectsList != null)
-                    for (int objIdx=0; objIdx < objectsList.Count; objIdx++)
-                        if (objectsList[objIdx] != null)
-                            yield return objectsList[objIdx];
+                if ((dependenciesNames == null) || (dependenciesNames.Contains(this.AllSymbolReferences[objListIdx].GetNameWithPublisher())))
+                {
+                    IList<T> objectsList = this.GetALAppObjectsCollection(this.AllSymbolReferences[objListIdx]);
+                    if (objectsList != null)
+                        for (int objIdx = 0; objIdx < objectsList.Count; objIdx++)
+                            if (objectsList[objIdx] != null)
+                                yield return objectsList[objIdx];
+                }
             }
         }
 

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/ALSymbols/ALMemberAccessExpression.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/ALSymbols/ALMemberAccessExpression.cs
@@ -16,5 +16,15 @@ namespace AnZwDev.ALTools.ALSymbols
             this.Expression = expression;
         }
 
+        public string GetValueWithourRec()
+        {
+            if (String.IsNullOrWhiteSpace(this.Expression))
+                return this.Name;
+            else if (this.Name.Equals("rec", StringComparison.CurrentCultureIgnoreCase))
+                return this.Expression;
+            return null;
+        }
+
+
     }
 }

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/ALSymbols/ALMemberAccessExpression.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/ALSymbols/ALMemberAccessExpression.cs
@@ -16,7 +16,7 @@ namespace AnZwDev.ALTools.ALSymbols
             this.Expression = expression;
         }
 
-        public string GetValueWithourRec()
+        public string GetSourceFieldNameWithoutRec()
         {
             if (String.IsNullOrWhiteSpace(this.Expression))
                 return this.Name;

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/ALSymbols/ALSyntaxHelper.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/ALSymbols/ALSyntaxHelper.cs
@@ -166,6 +166,9 @@ namespace AnZwDev.ALTools.ALSymbols
 
         public static ALMemberAccessExpression DecodeMemberAccessExpression(string expression)
         {
+            if (String.IsNullOrWhiteSpace(expression))
+                return new ALMemberAccessExpression("", null);
+
             expression = expression.Trim();
             int pos = FindMemberAccessSeparator(expression);
             if (pos < 0)

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/CodeAnalysis/AppSourceCopSettings.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/CodeAnalysis/AppSourceCopSettings.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Text;
 using System.IO;
 using Newtonsoft.Json;
+using AnZwDev.ALTools.Core;
 
 namespace AnZwDev.ALTools.CodeAnalysis
 {
@@ -33,7 +34,7 @@ namespace AnZwDev.ALTools.CodeAnalysis
             {
                 try
                 {
-                    string data = File.ReadAllText(path);
+                    string data = FileUtils.SafeReadAllText(path);
                     if (!String.IsNullOrWhiteSpace(data))
                         return AppSourceCopSettings.FromString(data);
                 }

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/CodeTransformations/BasePageWithSourceSyntaxRewriter.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/CodeTransformations/BasePageWithSourceSyntaxRewriter.cs
@@ -98,7 +98,7 @@ namespace AnZwDev.ALTools.CodeTransformations
                 if (!String.IsNullOrWhiteSpace(sourceTable))
                 {
                     this.TableName = sourceTable;
-                    this.TableFields = this.TableInformationProvider.GetTableFields(this.Project, sourceTable, false, false, true, true, true, false);
+                    this.TableFields = this.TableInformationProvider.GetTableFields(this.Project, sourceTable, false, false, true, true, true, false, null);
                 }
             }
         }
@@ -221,7 +221,7 @@ namespace AnZwDev.ALTools.CodeTransformations
             if (_tablesCollectionWithFields.ContainsKey(tableNameKey))
                 return _tablesCollectionWithFields[tableNameKey];
 
-            List<TableFieldInformaton> fields = this.TableInformationProvider.GetTableFields(this.Project, tableName, false, false, true, true, true, false);
+            List<TableFieldInformaton> fields = this.TableInformationProvider.GetTableFields(this.Project, tableName, false, false, true, true, true, false, null);
             _tablesCollectionWithFields.Add(tableNameKey, fields);
             return fields;
         }

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/CodeTransformations/BasePageWithSourceSyntaxRewriter.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/CodeTransformations/BasePageWithSourceSyntaxRewriter.cs
@@ -17,6 +17,7 @@ namespace AnZwDev.ALTools.CodeTransformations
 
         protected TableInformationProvider TableInformationProvider { get; }
         protected List<TableFieldInformaton> TableFields { get; set; }
+        protected String TableName { get; set; }
 
         protected ALSymbolKind _globalVarOwnerKind = ALSymbolKind.Undefined;
         protected string _globalVarOwnerName = null;
@@ -27,6 +28,7 @@ namespace AnZwDev.ALTools.CodeTransformations
         {
             this.TableInformationProvider = new TableInformationProvider();
             this.TableFields = null;
+            this.TableName = null;
         }
 
         public override SyntaxNode VisitReport(ReportSyntax node)
@@ -56,6 +58,7 @@ namespace AnZwDev.ALTools.CodeTransformations
         public override SyntaxNode VisitPageExtension(PageExtensionSyntax node)
         {
             this.TableFields = null;
+            this.TableName = null;
 
             //get list of table fields
             if (node.BaseObject != null)
@@ -67,6 +70,7 @@ namespace AnZwDev.ALTools.CodeTransformations
                 {
                     PageInformationProvider pageInformationProvider = new PageInformationProvider();
                     this.TableFields = pageInformationProvider.GetAllTableFieldsForPage(this.Project, pageName, false, false, true, true, true);
+                    this.TableName = this.Project.AllSymbols.Pages.FindObject(pageName)?.GetSourceTable();
                 }
             }
             else
@@ -86,15 +90,18 @@ namespace AnZwDev.ALTools.CodeTransformations
         {
             //try to find current table
             this.TableFields = null;
+            this.TableName = null;
             PropertyValueSyntax sourceTablePropertyValue = node.GetPropertyValue("SourceTable");
             if (sourceTablePropertyValue != null)
             {
                 string sourceTable = ALSyntaxHelper.DecodeName(sourceTablePropertyValue.ToString());
                 if (!String.IsNullOrWhiteSpace(sourceTable))
-                    this.TableFields = this.TableInformationProvider.GetTableFields(this.Project, sourceTable, false, false, true, true, true);
+                {
+                    this.TableName = sourceTable;
+                    this.TableFields = this.TableInformationProvider.GetTableFields(this.Project, sourceTable, false, false, true, true, true, false);
+                }
             }
         }
-
         protected TableFieldCaptionInfo GetFieldCaption(PageFieldSyntax node)
         {
             //try to find source field caption
@@ -126,14 +133,14 @@ namespace AnZwDev.ALTools.CodeTransformations
                     {
                         description = tableField.Description;
                         if ((tableField.CaptionLabel != null) && (!String.IsNullOrWhiteSpace(tableField.CaptionLabel.Value)))
-                            return new TableFieldCaptionInfo(tableField.CaptionLabel, description);
+                            return new TableFieldCaptionInfo(tableField.CaptionLabel, description, fieldName);
                     }
                 }
 
                 if ((String.IsNullOrWhiteSpace(caption)) && (fieldName != null))
                     caption = fieldName.Replace("\"", "").RemovePrefixSuffix(this.Project.MandatoryPrefixes, this.Project.MandatorySuffixes, this.Project.MandatoryAffixes);
             }
-            return new TableFieldCaptionInfo(new LabelInformation("Caption", caption), description);
+            return new TableFieldCaptionInfo(new LabelInformation("Caption", caption), description, null);
         }
 
         protected void SetGlobalVarOwner(ALSymbolKind kind, string name)
@@ -149,7 +156,7 @@ namespace AnZwDev.ALTools.CodeTransformations
             {
                 case ALSymbolKind.PageObject:
                     PageInformationProvider pageInformationProvider = new PageInformationProvider();
-                    this.SetGlobalVariables(pageInformationProvider.GetPageVariables(this.Project, _globalVarOwnerName));
+                    this.SetGlobalVariables(pageInformationProvider.GetVariables(this.Project, _globalVarOwnerName));
                     break;
                 case ALSymbolKind.ReportObject:
                     ReportInformationProvider reportInformationProvider = new ReportInformationProvider();
@@ -169,18 +176,18 @@ namespace AnZwDev.ALTools.CodeTransformations
             }
         }
 
-        protected void SetGlobalVariables(List<ALAppVariable> variables)
+        protected void SetGlobalVariables(IEnumerable<ALAppVariable> variables)
         {
             _globalVariables = new Dictionary<string, ALAppVariable>();
             if (variables != null)
             {
-                for (int i = 0; i < variables.Count; i++)
+                foreach (ALAppVariable alAppVariable in variables)
                 {
-                    if (!String.IsNullOrWhiteSpace(variables[i].Name))
+                    if (!String.IsNullOrWhiteSpace(alAppVariable.Name))
                     {
-                        string name = variables[i].Name.ToLower();
+                        string name = alAppVariable.Name.ToLower();
                         if (!_globalVariables.ContainsKey(name))
-                            _globalVariables.Add(name, variables[i]);
+                            _globalVariables.Add(name, alAppVariable);
                     }
                 }
             }
@@ -214,7 +221,7 @@ namespace AnZwDev.ALTools.CodeTransformations
             if (_tablesCollectionWithFields.ContainsKey(tableNameKey))
                 return _tablesCollectionWithFields[tableNameKey];
 
-            List<TableFieldInformaton> fields = this.TableInformationProvider.GetTableFields(this.Project, tableName, false, false, true, true, true);
+            List<TableFieldInformaton> fields = this.TableInformationProvider.GetTableFields(this.Project, tableName, false, false, true, true, true, false);
             _tablesCollectionWithFields.Add(tableNameKey, fields);
             return fields;
         }

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/CodeTransformations/BaseToolTipsSyntaxRewriter.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/CodeTransformations/BaseToolTipsSyntaxRewriter.cs
@@ -1,0 +1,54 @@
+﻿using AnZwDev.ALTools.CodeAnalysis;
+using AnZwDev.ALTools.Extensions;
+using Microsoft.Dynamics.Nav.CodeAnalysis;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Syntax;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace AnZwDev.ALTools.CodeTransformations
+{
+    public class BaseToolTipsSyntaxRewriter : BasePageWithSourceSyntaxRewriter
+    {
+
+        public BaseToolTipsSyntaxRewriter()
+        {
+        }
+
+        protected PageFieldSyntax SetPageFieldToolTip(PageFieldSyntax node, string newToolTip)
+        {
+            PropertySyntax propertySyntax = node.GetProperty("ToolTip");
+            if (propertySyntax == null)
+            {
+                SyntaxTriviaList leadingTriviaList = node.CreateChildNodeIdentTrivia();
+                SyntaxTriviaList trailingTriviaList = SyntaxFactory.ParseTrailingTrivia("\r\n", 0);
+                return node.AddPropertyListProperties(
+                    SyntaxFactoryHelper.ToolTipProperty(newToolTip, "", false)
+                        .WithLeadingTrivia(leadingTriviaList)
+                        .WithTrailingTrivia(trailingTriviaList));
+            }
+            else
+            {
+                bool validValue = true;
+                if (propertySyntax.Value is LabelPropertyValueSyntax labelValue)
+                    validValue = ((labelValue.Value?.LabelText?.Value.Value?.ToString()) != newToolTip);
+                if (validValue)
+                {
+                    PropertySyntax newPropertySyntax = SyntaxFactoryHelper.ToolTipProperty(newToolTip, "", false)
+                        .WithTriviaFrom(propertySyntax);
+                    return node.ReplaceNode(propertySyntax, newPropertySyntax);
+                }
+            }
+            return null;
+        }
+
+        protected PropertySyntax CreateToolTipProperty(string toolTipValue, SyntaxTriviaList leadingTriviaList, SyntaxTriviaList trailingTriviaList)
+        {
+            return SyntaxFactoryHelper.ToolTipProperty(toolTipValue, "", false)
+                .WithLeadingTrivia(leadingTriviaList)
+                .WithTrailingTrivia(trailingTriviaList);
+        }
+
+
+    }
+}

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/CodeTransformations/LockRemovedFieldsCaptionsSyntaxRewriter.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/CodeTransformations/LockRemovedFieldsCaptionsSyntaxRewriter.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using AnZwDev.ALTools.ALSymbols;
+using AnZwDev.ALTools.CodeAnalysis;
+using AnZwDev.ALTools.Extensions;
+using Microsoft.Dynamics.Nav.CodeAnalysis;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Syntax;
+
+namespace AnZwDev.ALTools.CodeTransformations
+{
+    public class LockRemovedFieldsCaptionsSyntaxRewriter : ALCaptionsSyntaxRewriter
+    {
+
+        public LockRemovedFieldsCaptionsSyntaxRewriter()
+        {
+        }
+
+        public override SyntaxNode VisitField(FieldSyntax node)
+        {
+            if (this.IsFieldRemoved(node))
+            {
+                PropertySyntax propertySyntax = node.GetProperty("Caption");
+                LabelSyntax labelSyntax = (propertySyntax?.Value as LabelPropertyValueSyntax)?.Value;
+                if (labelSyntax != null)
+                {
+                    if (!this.IsLocked(labelSyntax.Properties))
+                    {
+                        LabelSyntax newLabelSyntax;
+                        CommaSeparatedIdentifierEqualsLiteralListSyntax propertiesList = labelSyntax.Properties;
+                        if (propertiesList == null)
+                            newLabelSyntax = labelSyntax
+                                .WithCommaToken(SyntaxFactory.Token(EnumExtensions.FromString("CommaToken", SyntaxKind.CommaToken)))
+                                .WithProperties(this.CreateCaptionLockedProperties());
+                        else
+                            newLabelSyntax = labelSyntax.WithProperties(propertiesList.AddValues(this.CreateLockedProperty()));
+
+                        NoOfChanges++;
+                        return node.ReplaceNode(labelSyntax, newLabelSyntax);
+                    }
+                }
+            }
+            return base.VisitField(node);
+        }
+
+        protected CommaSeparatedIdentifierEqualsLiteralListSyntax CreateCaptionLockedProperties()
+        {
+            List<IdentifierEqualsLiteralSyntax> propertiesList = new List<IdentifierEqualsLiteralSyntax>();
+            propertiesList.Add(this.CreateLockedProperty());
+            SeparatedSyntaxList<IdentifierEqualsLiteralSyntax> separatedSyntaxList = new SeparatedSyntaxList<IdentifierEqualsLiteralSyntax>();
+            separatedSyntaxList = separatedSyntaxList.AddRange(propertiesList);
+            return SyntaxFactory.CommaSeparatedIdentifierEqualsLiteralList(separatedSyntaxList);
+        }
+
+        protected IdentifierEqualsLiteralSyntax CreateLockedProperty()
+        {
+            return SyntaxFactoryHelper.IdentifierEqualsLiteral("Locked", true);
+        }
+
+        protected bool IsLocked(CommaSeparatedIdentifierEqualsLiteralListSyntax propertiesList)
+        {
+            if (propertiesList != null)
+                foreach (var property in propertiesList.Values)
+                    if (property.Identifier.ValueText?.ToLower() == "locked")
+                        return true;
+            return false;
+        }
+
+        protected bool IsFieldRemoved(FieldSyntax node)
+        {
+            PropertyValueSyntax obsoleteStateSyntax = node.GetPropertyValue("ObsoleteState");
+            if (obsoleteStateSyntax == null)
+                return false;
+            string value = ALSyntaxHelper.DecodeName(obsoleteStateSyntax.ToString());
+            return ((value != null) && (value.Equals("Removed", StringComparison.CurrentCultureIgnoreCase)));
+        }
+
+    }
+}

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/CodeTransformations/RefreshToolTipsSyntaxRewriter.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/CodeTransformations/RefreshToolTipsSyntaxRewriter.cs
@@ -8,7 +8,7 @@ using System.Text;
 
 namespace AnZwDev.ALTools.CodeTransformations
 {
-    public class RefreshToolTipsSyntaxRewriter : BasePageWithSourceSyntaxRewriter
+    public class RefreshToolTipsSyntaxRewriter : BaseToolTipsSyntaxRewriter
     {
 
         public Dictionary<string, Dictionary<string, List<string>>> ToolTipsCache { get; set; }
@@ -34,24 +34,12 @@ namespace AnZwDev.ALTools.CodeTransformations
                         if ((fieldToolTipsCache.Count > 0) && (!String.IsNullOrWhiteSpace(fieldToolTipsCache[0])))
                         {
                             string newToolTip = fieldToolTipsCache[0];
-                            
-                            PropertySyntax propertySyntax = node.GetProperty("ToolTip");
-                            if (propertySyntax == null)
+
+                            PageFieldSyntax newNode = this.SetPageFieldToolTip(node, newToolTip);
+                            if (newNode != null)
                             {
                                 NoOfChanges++;
-                                SyntaxTriviaList leadingTriviaList = node.CreateChildNodeIdentTrivia();
-                                SyntaxTriviaList trailingTriviaList = SyntaxFactory.ParseTrailingTrivia("\r\n", 0);
-                                return node.AddPropertyListProperties(
-                                    SyntaxFactoryHelper.ToolTipProperty(newToolTip, "", false)
-                                        .WithLeadingTrivia(leadingTriviaList)
-                                        .WithTrailingTrivia(trailingTriviaList));
-                            }
-                            else
-                            {
-                                NoOfChanges++;
-                                PropertySyntax newPropertySyntax = SyntaxFactoryHelper.ToolTipProperty(newToolTip, "", false)
-                                    .WithTriviaFrom(propertySyntax);
-                                return node.ReplaceNode(propertySyntax, newPropertySyntax);
+                                return newNode;
                             }
                         }
                     }
@@ -59,13 +47,6 @@ namespace AnZwDev.ALTools.CodeTransformations
             }
 
             return base.VisitPageField(node);
-        }
-
-        protected PropertySyntax CreateToolTipProperty(string toolTipValue, SyntaxTriviaList leadingTriviaList, SyntaxTriviaList trailingTriviaList)
-        {
-            return SyntaxFactoryHelper.ToolTipProperty(toolTipValue, "", false)
-                .WithLeadingTrivia(leadingTriviaList)
-                .WithTrailingTrivia(trailingTriviaList);
         }
 
     }

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/CodeTransformations/RefreshToolTipsSyntaxRewriter.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/CodeTransformations/RefreshToolTipsSyntaxRewriter.cs
@@ -1,0 +1,72 @@
+﻿using AnZwDev.ALTools.CodeAnalysis;
+using AnZwDev.ALTools.Extensions;
+using Microsoft.Dynamics.Nav.CodeAnalysis;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Syntax;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace AnZwDev.ALTools.CodeTransformations
+{
+    public class RefreshToolTipsSyntaxRewriter : BasePageWithSourceSyntaxRewriter
+    {
+
+        public Dictionary<string, Dictionary<string, List<string>>> ToolTipsCache { get; set; }
+
+        public RefreshToolTipsSyntaxRewriter()
+        {
+        }
+
+        public override SyntaxNode VisitPageField(PageFieldSyntax node)
+        {
+            if ((!node.ContainsDiagnostics) && (this.ToolTipsCache != null) && (!String.IsNullOrWhiteSpace(this.TableName)) && (!node.HasProperty("ToolTipML")))
+            {
+                //find first tooltip from other pages
+                TableFieldCaptionInfo captionInfo = this.GetFieldCaption(node);
+                string tableNameKey = this.TableName.ToLower();
+                if (this.ToolTipsCache.ContainsKey(tableNameKey))
+                {
+                    Dictionary<string, List<string>> tableToolTipsCache = this.ToolTipsCache[tableNameKey];
+                    string fieldNameKey = captionInfo.FieldName.ToLower();
+                    if (tableToolTipsCache.ContainsKey(fieldNameKey))
+                    {
+                        List<string> fieldToolTipsCache = tableToolTipsCache[fieldNameKey];
+                        if ((fieldToolTipsCache.Count > 0) && (!String.IsNullOrWhiteSpace(fieldToolTipsCache[0])))
+                        {
+                            string newToolTip = fieldToolTipsCache[0];
+                            
+                            PropertySyntax propertySyntax = node.GetProperty("ToolTip");
+                            if (propertySyntax == null)
+                            {
+                                NoOfChanges++;
+                                SyntaxTriviaList leadingTriviaList = node.CreateChildNodeIdentTrivia();
+                                SyntaxTriviaList trailingTriviaList = SyntaxFactory.ParseTrailingTrivia("\r\n", 0);
+                                return node.AddPropertyListProperties(
+                                    SyntaxFactoryHelper.ToolTipProperty(newToolTip, "", false)
+                                        .WithLeadingTrivia(leadingTriviaList)
+                                        .WithTrailingTrivia(trailingTriviaList));
+                            }
+                            else
+                            {
+                                NoOfChanges++;
+                                PropertySyntax newPropertySyntax = SyntaxFactoryHelper.ToolTipProperty(newToolTip, "", false)
+                                    .WithTriviaFrom(propertySyntax);
+                                return node.ReplaceNode(propertySyntax, newPropertySyntax);
+                            }
+                        }
+                    }
+                }
+            }
+
+            return base.VisitPageField(node);
+        }
+
+        protected PropertySyntax CreateToolTipProperty(string toolTipValue, SyntaxTriviaList leadingTriviaList, SyntaxTriviaList trailingTriviaList)
+        {
+            return SyntaxFactoryHelper.ToolTipProperty(toolTipValue, "", false)
+                .WithLeadingTrivia(leadingTriviaList)
+                .WithTrailingTrivia(trailingTriviaList);
+        }
+
+    }
+}

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/CodeTransformations/RemoveBeginEndSyntaxRewriter.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/CodeTransformations/RemoveBeginEndSyntaxRewriter.cs
@@ -1,0 +1,177 @@
+﻿using AnZwDev.ALTools.ALSymbols.Internal;
+using AnZwDev.ALTools.Extensions;
+using Microsoft.Dynamics.Nav.CodeAnalysis;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Syntax;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace AnZwDev.ALTools.CodeTransformations
+{
+    public class RemoveBeginEndSyntaxRewriter : ALSyntaxRewriter
+    {
+
+        public RemoveBeginEndSyntaxRewriter()
+        {
+        }
+
+        public override SyntaxNode VisitBlock(BlockSyntax node)
+        {
+            //run checks
+            bool hasDiagnostics = node.ContainsDiagnostics;
+            SyntaxNode parent = node.Parent;
+            ConvertedSyntaxKind parentKind = parent.Kind.ConvertToLocalType();
+            bool isIfInIfElse = this.CheckIsIfInIfElse(node, parentKind);
+            bool isInIfWithElse = this.CheckIsInIfWithElse(node, parentKind);
+
+            SyntaxNode updatedNode = base.VisitBlock(node);
+
+            if ((updatedNode != null) && (updatedNode is BlockSyntax blockSyntax) && (!hasDiagnostics))
+            {
+                if ((parentKind != ConvertedSyntaxKind.TriggerDeclaration) &&
+                    (parentKind != ConvertedSyntaxKind.MethodDeclaration) &&
+                    (blockSyntax.Statements != null) &&
+                    (blockSyntax.Statements.Count <= 1) &&
+                    (!isIfInIfElse))
+                {
+                    this.NoOfChanges++;
+
+                    StatementSyntax newStatement;
+
+                    if (blockSyntax.Statements.Count == 1)
+                        newStatement = blockSyntax.Statements[0];
+                    else
+                        newStatement = SyntaxFactory.EmptyStatement();
+
+
+                    //remove semicolon if inside if statement with else                        
+                    if (isInIfWithElse)
+                    {
+                        //it is not possible to remove semicolon from empty statement, we have to leave begin..end
+                        if (newStatement.Kind.ConvertToLocalType() == ConvertedSyntaxKind.EmptyStatement)
+                            return updatedNode;
+                        newStatement = this.RemoveSemicolonToken(newStatement);
+                    }
+
+                    //trivia
+                    IEnumerable<SyntaxTrivia> leadingTrivia = node.GetLeadingTrivia();
+                    IEnumerable<SyntaxTrivia> trailingTrivia = node.GetTrailingTrivia();
+#if BC
+                    leadingTrivia = leadingTrivia.MergeWith(node.BeginKeywordToken.GetAllTrivia());
+                    trailingTrivia = node.EndKeywordToken.GetAllTrivia().MergeWith(trailingTrivia);
+#endif
+                    leadingTrivia = leadingTrivia.MergeWith(newStatement.GetLeadingTrivia());
+                    trailingTrivia = newStatement.GetTrailingTrivia().MergeWith(trailingTrivia).RemoveEmptyLines();
+
+                    newStatement = newStatement
+                        .WithLeadingTrivia(leadingTrivia)
+                        .WithTrailingTrivia(trailingTrivia);
+
+                    return newStatement;
+                }
+            }
+
+            return updatedNode;
+        }
+
+        protected StatementSyntax RemoveSemicolonToken(StatementSyntax node)
+        {
+            IEnumerable<SyntaxTrivia> trailingTrivia = null;
+
+            switch (node)
+            {
+                case BlockSyntax blockSyntax:
+                    trailingTrivia = this.GetStatementTrailingTrivia(node, blockSyntax.SemicolonToken);
+                    node = blockSyntax.WithSemicolonToken(default(SyntaxToken));
+                    break;
+                case AssignmentStatementSyntax assignmentStatement:
+                    trailingTrivia = this.GetStatementTrailingTrivia(node, assignmentStatement.SemicolonToken);
+                    node = assignmentStatement.WithSemicolonToken(default(SyntaxToken));
+                    break;
+                case BreakStatementSyntax breakStatement:
+                    trailingTrivia = this.GetStatementTrailingTrivia(node, breakStatement.SemicolonToken);
+                    node = breakStatement.WithSemicolonToken(default(SyntaxToken));
+                    break;
+                case CaseStatementSyntax caseStatement:
+                    trailingTrivia = this.GetStatementTrailingTrivia(node, caseStatement.SemicolonToken);
+                    node = caseStatement.WithSemicolonToken(default(SyntaxToken));
+                    break;
+                case CompoundAssignmentStatementSyntax compoundAssignmentStatement:
+                    trailingTrivia = this.GetStatementTrailingTrivia(node, compoundAssignmentStatement.SemicolonToken);
+                    node = compoundAssignmentStatement.WithSemicolonToken(default(SyntaxToken));
+                    break;
+                case EmptyStatementSyntax emptyStatement:
+                    trailingTrivia = this.GetStatementTrailingTrivia(node, emptyStatement.SemicolonToken);
+                    node = emptyStatement.WithSemicolonToken(default(SyntaxToken));
+                    break;
+                case ExitStatementSyntax exitStatement:
+                    trailingTrivia = this.GetStatementTrailingTrivia(node, exitStatement.SemicolonToken);
+                    node = exitStatement.WithSemicolonToken(default(SyntaxToken));
+                    break;
+                case ExpressionStatementSyntax expressionStatement:
+                    trailingTrivia = this.GetStatementTrailingTrivia(node, expressionStatement.SemicolonToken);
+                    node = expressionStatement.WithSemicolonToken(default(SyntaxToken));
+                    break;
+                case RepeatStatementSyntax repeatStatement:
+                    trailingTrivia = this.GetStatementTrailingTrivia(node, repeatStatement.SemicolonToken);
+                    node = repeatStatement.WithSemicolonToken(default(SyntaxToken));
+                    break;
+                case AssertErrorStatementSyntax assertErrorStatement:
+                    node = assertErrorStatement.WithStatement(this.RemoveSemicolonToken(assertErrorStatement.Statement));
+                    break;
+                case ForEachStatementSyntax forEachStatement:
+                    node = forEachStatement.WithStatement(this.RemoveSemicolonToken(forEachStatement.Statement));
+                    break;
+                case ForStatementSyntax forStatement:
+                    node = forStatement.WithStatement(this.RemoveSemicolonToken(forStatement.Statement));
+                    break;
+                case IfStatementSyntax ifStatement:
+                    if (ifStatement.ElseStatement != null)
+                        node = ifStatement.WithElseStatement(this.RemoveSemicolonToken(ifStatement.ElseStatement));
+                    else
+                        node = ifStatement.WithStatement(this.RemoveSemicolonToken(ifStatement.Statement));
+                    break;
+                case OrphanedElseStatementSyntax orphanedElseStatement:
+                    node = orphanedElseStatement.WithElseStatement(this.RemoveSemicolonToken(orphanedElseStatement.ElseStatement));
+                    break;
+                case WhileStatementSyntax whileStatement:
+                    node = whileStatement.WithStatement(this.RemoveSemicolonToken(whileStatement.Statement));
+                    break;
+                case WithStatementSyntax withStatement:
+                    node = withStatement.WithStatement(this.RemoveSemicolonToken(withStatement.Statement));
+                    break;
+            }
+            if (trailingTrivia != null)
+                node = node.WithTrailingTrivia(trailingTrivia);
+            return node;
+        }
+
+        protected IEnumerable<SyntaxTrivia> GetStatementTrailingTrivia(SyntaxNode node, SyntaxToken semicolonToken)
+        {
+#if BC
+            if (semicolonToken != null)
+                return semicolonToken.GetAllTrivia().MergeWith(node.GetTrailingTrivia());
+#endif
+            return null;
+        }
+
+        private bool CheckIsInIfWithElse(BlockSyntax node, ConvertedSyntaxKind parentKind)
+        {
+            return (parentKind == ConvertedSyntaxKind.IfStatement) &&
+                (node.Parent is IfStatementSyntax parentIf) &&
+                (parentIf.Statement == node) &&
+                (parentIf.ElseStatement != null);
+        }
+
+        private bool CheckIsIfInIfElse(BlockSyntax node, ConvertedSyntaxKind parentKind)
+        {
+            return (parentKind == ConvertedSyntaxKind.IfStatement) &&
+                (node.Statements.Count == 1) &&
+                (node.Statements[0].Kind.ConvertToLocalType() == ConvertedSyntaxKind.IfStatement) &&
+                (node.Parent is IfStatementSyntax parentIf) &&
+                (parentIf.Statement == node) &&
+                (parentIf.ElseStatement != null);
+        }
+
+    }
+}

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/CodeTransformations/SetPageFieldToolTipSyntaxRewriter.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/CodeTransformations/SetPageFieldToolTipSyntaxRewriter.cs
@@ -1,0 +1,35 @@
+﻿using AnZwDev.ALTools.CodeAnalysis;
+using AnZwDev.ALTools.Extensions;
+using Microsoft.Dynamics.Nav.CodeAnalysis;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Syntax;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace AnZwDev.ALTools.CodeTransformations
+{
+    public class SetPageFieldToolTipSyntaxRewriter : BaseToolTipsSyntaxRewriter
+    {
+
+        public string ToolTip { get; set; }
+
+        public SetPageFieldToolTipSyntaxRewriter()
+        {
+        }
+
+        public override SyntaxNode VisitPageField(PageFieldSyntax node)
+        {
+            if ((!node.ContainsDiagnostics) && (!String.IsNullOrWhiteSpace(this.ToolTip)) && (this.Span != null) && (node.Span.IntersectsWith(this.Span)))
+            {
+                PageFieldSyntax newNode = this.SetPageFieldToolTip(node, this.ToolTip);
+                if (newNode != null)
+                {
+                    NoOfChanges++;
+                    return newNode;
+                }
+            }
+            return base.VisitPageField(node);
+        }
+
+    }
+}

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/CodeTransformations/TableFieldCaptionInfo.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/CodeTransformations/TableFieldCaptionInfo.cs
@@ -7,20 +7,21 @@ namespace AnZwDev.ALTools.CodeTransformations
 {
     public class TableFieldCaptionInfo
     {
-
+        public string FieldName { get; set; }
         public LabelInformation Caption { get; set; }
         public string Description { get; set; }
 
-        public TableFieldCaptionInfo() : this(null, null)
+        public TableFieldCaptionInfo() : this(null, null, null)
         {
         }
 
-        public TableFieldCaptionInfo(LabelInformation caption) : this(caption, null)
+        public TableFieldCaptionInfo(LabelInformation caption) : this(caption, null, null)
         {
         }
 
-        public TableFieldCaptionInfo(LabelInformation caption, string description)
+        public TableFieldCaptionInfo(LabelInformation caption, string description, string fieldName)
         {
+            this.FieldName = fieldName;
             this.Caption = caption;
             this.Description = description;
         }

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/Core/FileUtils.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/Core/FileUtils.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.IO;
+using AnZwDev.ALTools.Logging;
+
+namespace AnZwDev.ALTools.Core
+{
+    public static class FileUtils
+    {
+
+        public static string ReadAllText(string path)
+        {
+            string content = "";
+            using (FileStream stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))            
+            using (StreamReader reader = new StreamReader(stream))
+                    content = reader.ReadToEnd();
+            return content;
+        }
+
+        public static string SafeReadAllText(string path)
+        {
+            //try to read file 4 times
+            int retryCounter = 4;
+            for (int i = 0; i < retryCounter; i++)
+            {
+                try
+                {
+                    return FileUtils.ReadAllText(path);
+                }
+                catch (FileNotFoundException fileNotFoundException)
+                {
+                    MessageLog.LogError(fileNotFoundException);
+                    return "";
+                }
+                catch (Exception ex)
+                {
+                    if (i == (retryCounter - 1))
+                        MessageLog.LogError(ex);
+                    else
+                        System.Threading.Thread.Sleep(200);
+                }
+            }
+            return "";
+        }
+
+    }
+}

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/Extensions/DictionaryExtensions.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/Extensions/DictionaryExtensions.cs
@@ -31,5 +31,14 @@ namespace AnZwDev.ALTools.Extensions
             return value.Split(split);
         }
 
+        public static ET FindOrCreate<KT, ET>(this Dictionary<KT, ET> dictionary, KT key) where ET : new()
+        {
+            if (dictionary.ContainsKey(key))
+                return dictionary[key];
+            ET value = new ET();
+            dictionary.Add(key, value);
+            return value;
+        }
+
     }
 }

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/Extensions/IEnumerableExtensions.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/Extensions/IEnumerableExtensions.cs
@@ -19,5 +19,23 @@ namespace AnZwDev.ALTools.Extensions
                         yield return item;
         }
 
+        public static HashSet<T> ToHashSet<T>(this IEnumerable<T> enumerable)
+        {
+            HashSet<T> hashSet = new HashSet<T>();
+            foreach (T item in enumerable)
+                hashSet.Add(item);
+            return hashSet;
+        }
+
+        public static HashSet<string> ToLowerCaseHashSet(this IEnumerable<string> enumerable)
+        {
+            HashSet<string> hashSet = new HashSet<string>();
+            foreach (string item in enumerable)
+                hashSet.Add(item.ToLower());
+            return hashSet;
+        }
+
+
+
     }
 }

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/Extensions/IEnumerableExtensions.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/Extensions/IEnumerableExtensions.cs
@@ -19,11 +19,17 @@ namespace AnZwDev.ALTools.Extensions
                         yield return item;
         }
 
-        public static HashSet<T> ToHashSet<T>(this IEnumerable<T> enumerable)
+        public static HashSet<T> ToHashSet<T>(this IEnumerable<T> enumerable, bool nullIfEmpty)
         {
+            bool isEmpty = true;
             HashSet<T> hashSet = new HashSet<T>();
             foreach (T item in enumerable)
+            {
                 hashSet.Add(item);
+                isEmpty = false;
+            }
+            if (isEmpty)
+                return null;
             return hashSet;
         }
 

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/Extensions/StringExtensions.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/Extensions/StringExtensions.cs
@@ -123,12 +123,43 @@ namespace AnZwDev.ALTools.Extensions
             return text;
         }
 
-
         public static List<string> ToSingleElementList(this string text)
         {
             List<string> list = new List<string>();
             list.Add(text);
             return list;
+        }
+
+        public static string MultilineTrimEnd(this string text)
+        {
+            if (String.IsNullOrEmpty(text))
+                return text;
+
+            StringBuilder stringBuilder = new StringBuilder();
+            int startPos = 0;
+            int endPos = -1;
+
+            for (int i = 0; i < text.Length; i++)
+            {
+                char character = text[i];
+                bool isNewLine = (character == '\n') || (character == '\r');
+                bool isWhitespace = (Char.IsWhiteSpace(character) && (!isNewLine));
+
+                if (!isWhitespace)
+                {
+                    if (isNewLine)
+                    {
+                        if (endPos >= startPos)
+                            stringBuilder.Append(text.Substring(startPos, endPos + 1 - startPos));
+                        startPos = i;
+                    }
+                    endPos = i;
+                }
+            }
+            if (endPos >= startPos)
+                stringBuilder.Append(text.Substring(startPos, endPos + 1 - startPos));
+
+            return stringBuilder.ToString();
         }
 
     }

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/Extensions/SyntaxTriviaListExtensions.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/Extensions/SyntaxTriviaListExtensions.cs
@@ -35,5 +35,38 @@ namespace AnZwDev.ALTools.Extensions
             return SyntaxFactory.TriviaList(newList);
         }
 
+        public static List<SyntaxTrivia> RemoveEmptyLines(this IEnumerable<SyntaxTrivia> triviaList)
+        {
+            List<SyntaxTrivia> newList = new List<SyntaxTrivia>();
+            bool validLine = true;
+            int lastValidPos = -1;
+
+            foreach (SyntaxTrivia trivia in triviaList)
+            {
+                //add trivia to the list
+                newList.Add(trivia);
+                
+                ConvertedSyntaxKind kind = trivia.Kind.ConvertToLocalType();
+
+                if (kind == ConvertedSyntaxKind.EndOfLineTrivia)
+                {
+                    //if valid line, then remember this trivia as last valid position
+                    //if invalid line, remove elements after last valid position
+                    if (validLine)
+                        lastValidPos = newList.Count - 1;
+                    else
+                        newList.RemoveRange(lastValidPos + 1, newList.Count - lastValidPos - 1);
+                    validLine = false;
+                } 
+                else if (kind != ConvertedSyntaxKind.WhiteSpaceTrivia)
+                    validLine = true;
+
+                if (validLine)
+                    lastValidPos = newList.Count - 1;
+            }
+
+            return newList;
+        }
+
     }
 }

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/Shared.AnZwDev.ALTools.projitems
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/Shared.AnZwDev.ALTools.projitems
@@ -178,6 +178,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)CodeTransformations\ToolTipSyntaxRewriter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CodeTransformations\WithIdentifiersSyntaxRewriter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CodeTransformations\WithRemoveSyntaxRewriter.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Core\FileUtils.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Core\PathUtils.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Core\VersionNumber.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\AlphanumComparatorFast .cs" />

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/Shared.AnZwDev.ALTools.projitems
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/Shared.AnZwDev.ALTools.projitems
@@ -152,6 +152,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)CodeTransformations\ALSyntaxRewriter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CodeTransformations\AppAreaSyntaxRewriter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CodeTransformations\BasePageWithSourceSyntaxRewriter.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)CodeTransformations\BaseToolTipsSyntaxRewriter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CodeTransformations\RefreshToolTipsSyntaxRewriter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CodeTransformations\RemoveBeginEndSyntaxRewriter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CodeTransformations\ConvertObjectIdsToNamesSyntaxRewriter.cs" />
@@ -166,6 +167,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)CodeTransformations\PermissionComparer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CodeTransformations\RemoveUnusedVariablesSyntaxRewriter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CodeTransformations\RemoveVariableSyntaxRewriter.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)CodeTransformations\SetPageFieldToolTipSyntaxRewriter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CodeTransformations\SortPermissionSetListSyntaxRewriter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CodeTransformations\SortPermissionsSyntaxRewriter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CodeTransformations\SortProceduresSyntaxRewriter.cs" />
@@ -221,6 +223,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)WorkspaceCommands\RemoveWithWorkspaceCommand.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)WorkspaceCommands\SemanticModelSyntaxRewriterWorkspaceCommand.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)WorkspaceCommands\SemanticModelWorkspaceCommand.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)WorkspaceCommands\SetPageFieldToolTipWorkspaceCommand.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)WorkspaceCommands\SortPermissionSetListWorkspaceCommand.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)WorkspaceCommands\SortPermissionsWorkspaceCommand.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)WorkspaceCommands\SortProceduresWorkspaceCommand.cs" />

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/Shared.AnZwDev.ALTools.projitems
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/Shared.AnZwDev.ALTools.projitems
@@ -195,6 +195,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\TypeExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Logging\IMessageLogWriter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Logging\MessageLog.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)SourceControl\GitClient.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)WorkspaceCommands\AddAppAreasWorkspaceCommand.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)WorkspaceCommands\AddDataClassificationWorkspaceCommand.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)WorkspaceCommands\AddFieldCaptionsWorkspaceCommand.cs" />

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/Shared.AnZwDev.ALTools.projitems
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/Shared.AnZwDev.ALTools.projitems
@@ -150,6 +150,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)CodeTransformations\ALSyntaxRewriter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CodeTransformations\AppAreaSyntaxRewriter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CodeTransformations\BasePageWithSourceSyntaxRewriter.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)CodeTransformations\RemoveBeginEndSyntaxRewriter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CodeTransformations\ConvertObjectIdsToNamesSyntaxRewriter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CodeTransformations\DataClassificationSyntaxRewriter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CodeTransformations\FieldCaptionSyntaxRewriter.cs" />
@@ -209,6 +210,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)WorkspaceCommands\FixKeywordsCaseWorkspaceCommand.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)WorkspaceCommands\FormatDocumentWorkspaceCommand.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)WorkspaceCommands\LockRemovedFieldsCaptionsWorkspaceCommand.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)WorkspaceCommands\RemoveBeginEndWorkspaceCommand.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)WorkspaceCommands\RemoveUnusedVariablesWorkspaceCommand.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)WorkspaceCommands\RemoveVariableWorkspaceCommand.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)WorkspaceCommands\RemoveWithWorkspaceCommand.cs" />

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/Shared.AnZwDev.ALTools.projitems
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/Shared.AnZwDev.ALTools.projitems
@@ -156,6 +156,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)CodeTransformations\IdentifierCaseSyntaxRewriter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CodeTransformations\IdentifierNameComparer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CodeTransformations\KeywordCaseSyntaxRewriter.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)CodeTransformations\LockRemovedFieldsCaptionsSyntaxRewriter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CodeTransformations\ObjectCaptionSyntaxRewriter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CodeTransformations\PageControlCaptionSyntaxRewriter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CodeTransformations\PermissionComparer.cs" />
@@ -205,6 +206,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)WorkspaceCommands\ConvertObjectIdsToNamesWorkspaceCommand.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)WorkspaceCommands\FixIdentifiersCaseWorkspaceCommand.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)WorkspaceCommands\FixKeywordsCaseWorkspaceCommand.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)WorkspaceCommands\FormatDocumentWorkspaceCommand.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)WorkspaceCommands\LockRemovedFieldsCaptionsWorkspaceCommand.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)WorkspaceCommands\RemoveUnusedVariablesWorkspaceCommand.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)WorkspaceCommands\RemoveVariableWorkspaceCommand.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)WorkspaceCommands\RemoveWithWorkspaceCommand.cs" />
@@ -217,9 +220,11 @@
     <Compile Include="$(MSBuildThisFileDirectory)WorkspaceCommands\SortReportColumnsWorkspaceCommand.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)WorkspaceCommands\SortTableFieldsWorkspaceCommand.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)WorkspaceCommands\SortVariablesWorkspaceCommand.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)WorkspaceCommands\SourceTextWorkspaceCommand.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)WorkspaceCommands\SyntaxRewriterWorkspaceCommand.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)WorkspaceCommands\SyntaxTreeWorkspaceCommand.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)WorkspaceCommands\SyntaxTreeWorkspaceCommandsGroup.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)WorkspaceCommands\TrimTrailingWhitespaceWorkspaceCommand.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)WorkspaceCommands\WorkspaceCommand.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)WorkspaceCommands\WorkspaceCommandResult.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)WorkspaceCommands\WorkspaceCommandsManager.cs" />

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/Shared.AnZwDev.ALTools.projitems
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/Shared.AnZwDev.ALTools.projitems
@@ -84,7 +84,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)ALSymbolReferences\ALAppVariable.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ALSymbolReferences\ALAppXmlPort.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ALSymbolReferences\ALAppXmlPortNode.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)ALSymbolReferences\IALAppObjectExtension.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ALSymbolReferences\IReadOnlyALAppObjectsCollection.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)ALSymbolReferences\MergedReferences\ALAppObjectWithExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ALSymbolReferences\MergedReferences\MergedALAppObjectExtensionsCollection.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ALSymbolReferences\MergedReferences\MergedALAppObjectsCollection.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ALSymbolReferences\MergedReferences\MergedALAppSymbolReference.cs" />
@@ -150,6 +152,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)CodeTransformations\ALSyntaxRewriter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CodeTransformations\AppAreaSyntaxRewriter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CodeTransformations\BasePageWithSourceSyntaxRewriter.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)CodeTransformations\RefreshToolTipsSyntaxRewriter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CodeTransformations\RemoveBeginEndSyntaxRewriter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CodeTransformations\ConvertObjectIdsToNamesSyntaxRewriter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CodeTransformations\DataClassificationSyntaxRewriter.cs" />
@@ -211,6 +214,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)WorkspaceCommands\FixKeywordsCaseWorkspaceCommand.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)WorkspaceCommands\FormatDocumentWorkspaceCommand.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)WorkspaceCommands\LockRemovedFieldsCaptionsWorkspaceCommand.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)WorkspaceCommands\RefreshToolTipsWorkspaceCommand.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)WorkspaceCommands\RemoveBeginEndWorkspaceCommand.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)WorkspaceCommands\RemoveUnusedVariablesWorkspaceCommand.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)WorkspaceCommands\RemoveVariableWorkspaceCommand.cs" />
@@ -261,6 +265,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)Workspace\SymbolsInformation\EnumInformationProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Workspace\SymbolsInformation\InterfaceInformation.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Workspace\SymbolsInformation\InterfaceInformationProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Workspace\SymbolsInformation\Internal\IntPageControlWithPropertyValue.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Workspace\SymbolsInformation\Internal\IntPageWithControlsWithPropertyValue.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Workspace\SymbolsInformation\LabelInformation.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Workspace\SymbolsInformation\MethodInformation.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Workspace\SymbolsInformation\ObjectIdInformationProvider.cs" />

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/SourceControl/GitClient.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/SourceControl/GitClient.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+
+namespace AnZwDev.ALTools.SourceControl
+{
+    public static class GitClient
+    {
+
+        public static string[] GetModifiedFiles(string path, string fileExt)
+        {
+            List<string> files = new List<string>();
+            bool hasExt = !String.IsNullOrWhiteSpace(fileExt);
+
+            Process process = new Process();
+            ProcessStartInfo startInfo = new ProcessStartInfo();
+            startInfo.UseShellExecute = false;
+            startInfo.RedirectStandardOutput = true;
+            startInfo.RedirectStandardError = true;
+            startInfo.WorkingDirectory = path;
+            startInfo.FileName = "git";
+            startInfo.Arguments = "ls-files -m";
+            process.StartInfo = startInfo;
+            process.Start();
+
+            StreamReader sr = process.StandardOutput;
+            while (!sr.EndOfStream)
+            {
+                string line = sr.ReadLine();
+                if (!String.IsNullOrWhiteSpace(line))
+                {
+                    string fileName = Path.Combine(path, line.Trim());
+                    if ((!hasExt) || (fileName.EndsWith(fileExt, StringComparison.CurrentCultureIgnoreCase)))
+                        files.Add(fileName);
+                }
+            }
+
+            process.WaitForExit();
+            if (process.ExitCode != 0)
+            {
+                string errorMessage = process.StandardError.ReadToEnd();
+                process.Close();
+                process.Dispose();
+                throw new Exception(errorMessage);
+            }
+
+            process.Close();
+            process.Dispose();
+
+            if (Path.DirectorySeparatorChar != '/')
+                for (int i = 0; i < files.Count; i++)
+                    files[i] = files[i].Replace('/', Path.DirectorySeparatorChar);
+
+            return files.ToArray();
+        }
+
+    }
+}

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/Workspace/ALProjectFile.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/Workspace/ALProjectFile.cs
@@ -7,6 +7,7 @@ using AnZwDev.ALTools.ALSymbolReferences;
 using AnZwDev.ALTools.ALSymbols;
 using AnZwDev.ALTools.ALSymbols.SymbolReaders;
 using AnZwDev.ALTools.Logging;
+using AnZwDev.ALTools.Core;
 
 namespace AnZwDev.ALTools.Workspace
 {
@@ -76,7 +77,7 @@ namespace AnZwDev.ALTools.Workspace
 
         public string ReadAllText()
         {
-            return File.ReadAllText(this.FullPath);
+            return FileUtils.SafeReadAllText(this.FullPath);
         }
 
         public void WriteAllText(string content)

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/Workspace/Serialization/ALProjectMetadataSerializer.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/Workspace/Serialization/ALProjectMetadataSerializer.cs
@@ -4,6 +4,7 @@ using System.Text;
 using System.IO;
 using Newtonsoft.Json;
 using AnZwDev.ALTools.Workspace;
+using AnZwDev.ALTools.Core;
 
 namespace AnZwDev.ALTools.Workspace.Serialization
 {
@@ -16,7 +17,7 @@ namespace AnZwDev.ALTools.Workspace.Serialization
 
         public static void LoadFromFile(ALProject project, string path)
         {
-            LoadFromJson(project, File.ReadAllText(path));
+            LoadFromJson(project, FileUtils.SafeReadAllText(path));
         }
 
         public static void LoadFromJson(ALProject project, string jsonContent)

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/Workspace/SymbolsInformation/BaseExtendableObjectInformationProvider.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/Workspace/SymbolsInformation/BaseExtendableObjectInformationProvider.cs
@@ -1,20 +1,27 @@
 ﻿using AnZwDev.ALTools.ALSymbolReferences;
+using AnZwDev.ALTools.ALSymbolReferences.MergedReferences;
 using System;
 using System.Collections.Generic;
 using System.Text;
 
 namespace AnZwDev.ALTools.Workspace.SymbolsInformation
 {
-    public class BaseExtendableObjectInformationProvider<T,E> : BaseObjectInformationProvider<T> where T: ALAppObject where E: ALAppObject
+    public class BaseExtendableObjectInformationProvider<T,E> : BaseObjectInformationProvider<T> where T: ALAppObject where E: ALAppObject, IALAppObjectExtension
     {
         public BaseExtendableObjectInformationProvider()
         {
         }
 
-        protected IEnumerable<E> FindAllExtensions(ALProject project, T alObject)
+        #region Object list and search
+
+        protected virtual MergedALAppObjectExtensionsCollection<E> GetALAppObjectExtensionsCollection(ALProject project)
         {
             return null;
         }
+
+        #endregion
+
+        #region Methods
 
         protected override IEnumerable<ALAppMethod> GetMethods(ALProject project, T alObject)
         {
@@ -28,7 +35,7 @@ namespace AnZwDev.ALTools.Workspace.SymbolsInformation
             }
 
             //extension methods
-            IEnumerable<E> extensions = this.FindAllExtensions(project, alObject);
+            IEnumerable<E> extensions = this.GetALAppObjectExtensionsCollection(project)?.FindAllExtensions(alObject.Name);
             if (extensions != null)
             {
                 foreach (E ext in extensions)
@@ -44,6 +51,10 @@ namespace AnZwDev.ALTools.Workspace.SymbolsInformation
             }
         }
 
+        #endregion
+
+        #region Variables
+
         protected override IEnumerable<ALAppVariable> GetVariables(ALProject project, T alObject)
         {
             //main methods
@@ -56,7 +67,7 @@ namespace AnZwDev.ALTools.Workspace.SymbolsInformation
             }
 
             //extension methods
-            IEnumerable<E> extensions = this.FindAllExtensions(project, alObject);
+            IEnumerable<E> extensions = this.GetALAppObjectExtensionsCollection(project)?.FindAllExtensions(alObject.Name);
             if (extensions != null)
             {
                 foreach (E ext in extensions)
@@ -72,6 +83,7 @@ namespace AnZwDev.ALTools.Workspace.SymbolsInformation
             }
         }
 
+        #endregion
 
     }
 }

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/Workspace/SymbolsInformation/Internal/IntPageControlWithPropertyValue.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/Workspace/SymbolsInformation/Internal/IntPageControlWithPropertyValue.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace AnZwDev.ALTools.Workspace.SymbolsInformation.Internal
+{
+    internal class IntPageControlWithPropertyValue
+    {
+
+        public string ControlName { get; set; }
+        public string ControlSource { get; set; }
+        public string PropertyValue { get; set; }
+
+    }
+}

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/Workspace/SymbolsInformation/Internal/IntPageWithControlsWithPropertyValue.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/Workspace/SymbolsInformation/Internal/IntPageWithControlsWithPropertyValue.cs
@@ -1,0 +1,78 @@
+﻿using AnZwDev.ALTools.ALSymbolReferences;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace AnZwDev.ALTools.Workspace.SymbolsInformation.Internal
+{
+    internal class IntPageWithControlsWithPropertyValue
+    {
+
+        public string Name { get; set; }
+        public string SourceTable { get; set; }
+        public string PropertyName { get; }
+        public Dictionary<string, IntPageControlWithPropertyValue> Controls { get; }
+
+        public IntPageWithControlsWithPropertyValue(ALAppPage alAppPage, string propertyName)
+        {
+            //get page properties
+            this.Controls = new Dictionary<string, IntPageControlWithPropertyValue>();
+            this.Name = alAppPage.Name;
+            this.PropertyName = propertyName;
+            if (alAppPage.Properties != null)
+                this.SourceTable = alAppPage.Properties.GetValue("SourceTable");
+
+            //add controls
+            this.AddControls(alAppPage.Controls);
+        }
+
+        protected void AddControls(ALAppElementsCollection<ALAppPageControl> alAppControlsList)
+        {
+            if (alAppControlsList != null)
+                for (int i = 0; i < alAppControlsList.Count; i++)
+                    this.AddControl(alAppControlsList[i]);
+        }
+
+        protected void AddControl(ALAppPageControl alAppControl)
+        {
+            //add control details
+            string expression = alAppControl.GetSourceExpression();
+            if (!String.IsNullOrWhiteSpace(expression))
+            {
+                string key = alAppControl.Name?.ToLower();
+                if (key != null)
+                {
+                    if (this.Controls.ContainsKey(key))
+                    {
+                        ALAppProperty property = alAppControl.Properties?.GetProperty(this.PropertyName);
+                        if ((property != null) && (property.Value != null))
+                            this.Controls[key].PropertyValue = property.Value;
+                    }
+                    else
+                    {
+                        this.Controls.Add(key, new IntPageControlWithPropertyValue()
+                        {
+                            ControlName = alAppControl.Name,
+                            ControlSource = expression,
+                            PropertyValue = alAppControl.Properties?.GetProperty(this.PropertyName)?.Value
+                        });
+                    }
+                }
+            }
+
+            //add child controls
+            this.AddControls(alAppControl.Controls);
+        }
+
+        public void ApplyPageExtension(ALAppPageExtension alAppPageExtension)
+        {
+            //collect control changes
+            if (alAppPageExtension.ControlChanges != null)
+                for (int i=0; i < alAppPageExtension.ControlChanges.Count; i++)
+                {
+                    this.AddControls(alAppPageExtension.ControlChanges[i].Controls);
+                }
+        }
+
+    }
+}

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/Workspace/SymbolsInformation/QueryInformationProvider.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/Workspace/SymbolsInformation/QueryInformationProvider.cs
@@ -104,7 +104,7 @@ namespace AnZwDev.ALTools.Workspace.SymbolsInformation
             if ((!String.IsNullOrWhiteSpace(queryDataItem.RelatedTable)) && (getExistingFields || getAvailableFields))
             {
                 TableInformationProvider tableInformationProvider = new TableInformationProvider();
-                List<TableFieldInformaton> allTableFieldsList = tableInformationProvider.GetTableFields(project, queryDataItem.RelatedTable, false, false, true, true, false);
+                List<TableFieldInformaton> allTableFieldsList = tableInformationProvider.GetTableFields(project, queryDataItem.RelatedTable, false, false, true, true, false, false);
 
                 Dictionary<string, TableFieldInformaton> availableTableFieldsDict = allTableFieldsList.ToDictionary();
                 List<TableFieldInformaton> reportDataItemFields = new List<TableFieldInformaton>();

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/Workspace/SymbolsInformation/QueryInformationProvider.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/Workspace/SymbolsInformation/QueryInformationProvider.cs
@@ -104,7 +104,7 @@ namespace AnZwDev.ALTools.Workspace.SymbolsInformation
             if ((!String.IsNullOrWhiteSpace(queryDataItem.RelatedTable)) && (getExistingFields || getAvailableFields))
             {
                 TableInformationProvider tableInformationProvider = new TableInformationProvider();
-                List<TableFieldInformaton> allTableFieldsList = tableInformationProvider.GetTableFields(project, queryDataItem.RelatedTable, false, false, true, true, false, false);
+                List<TableFieldInformaton> allTableFieldsList = tableInformationProvider.GetTableFields(project, queryDataItem.RelatedTable, false, false, true, true, false, false, null);
 
                 Dictionary<string, TableFieldInformaton> availableTableFieldsDict = allTableFieldsList.ToDictionary();
                 List<TableFieldInformaton> reportDataItemFields = new List<TableFieldInformaton>();

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/Workspace/SymbolsInformation/ReportInformationProvider.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/Workspace/SymbolsInformation/ReportInformationProvider.cs
@@ -162,7 +162,7 @@ namespace AnZwDev.ALTools.Workspace.SymbolsInformation
             {
                 string tableName = reportDataItem.RelatedTable;
                 TableInformationProvider tableInformationProvider = new TableInformationProvider();
-                List<TableFieldInformaton> allTableFieldsList = tableInformationProvider.GetTableFields(project, tableName, false, false, true, true, false, false);
+                List<TableFieldInformaton> allTableFieldsList = tableInformationProvider.GetTableFields(project, tableName, false, false, true, true, false, false, null);
 
                 ReportDataItemInformationFieldsBuffer dataItemFieldsBuffer = new ReportDataItemInformationFieldsBuffer(reportDataItemInformation);
                 dataItemFieldsBuffer.SetTable(tableName, allTableFieldsList);
@@ -326,7 +326,7 @@ namespace AnZwDev.ALTools.Workspace.SymbolsInformation
                     {
                         string tableName = dataItem.RelatedTable;
                         TableInformationProvider tableInformationProvider = new TableInformationProvider();
-                        List<TableFieldInformaton> allTableFieldsList = tableInformationProvider.GetTableFields(project, tableName, false, false, true, true, false, false);
+                        List<TableFieldInformaton> allTableFieldsList = tableInformationProvider.GetTableFields(project, tableName, false, false, true, true, false, false, null);
 
                         fieldsBuffer.SetTable(tableName, allTableFieldsList);
                     }

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/Workspace/SymbolsInformation/ReportInformationProvider.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/Workspace/SymbolsInformation/ReportInformationProvider.cs
@@ -162,7 +162,7 @@ namespace AnZwDev.ALTools.Workspace.SymbolsInformation
             {
                 string tableName = reportDataItem.RelatedTable;
                 TableInformationProvider tableInformationProvider = new TableInformationProvider();
-                List<TableFieldInformaton> allTableFieldsList = tableInformationProvider.GetTableFields(project, tableName, false, false, true, true, false);
+                List<TableFieldInformaton> allTableFieldsList = tableInformationProvider.GetTableFields(project, tableName, false, false, true, true, false, false);
 
                 ReportDataItemInformationFieldsBuffer dataItemFieldsBuffer = new ReportDataItemInformationFieldsBuffer(reportDataItemInformation);
                 dataItemFieldsBuffer.SetTable(tableName, allTableFieldsList);
@@ -326,7 +326,7 @@ namespace AnZwDev.ALTools.Workspace.SymbolsInformation
                     {
                         string tableName = dataItem.RelatedTable;
                         TableInformationProvider tableInformationProvider = new TableInformationProvider();
-                        List<TableFieldInformaton> allTableFieldsList = tableInformationProvider.GetTableFields(project, tableName, false, false, true, true, false);
+                        List<TableFieldInformaton> allTableFieldsList = tableInformationProvider.GetTableFields(project, tableName, false, false, true, true, false, false);
 
                         fieldsBuffer.SetTable(tableName, allTableFieldsList);
                     }

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/Workspace/SymbolsInformation/TableFieldInformaton.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/Workspace/SymbolsInformation/TableFieldInformaton.cs
@@ -25,7 +25,7 @@ namespace AnZwDev.ALTools.Workspace.SymbolsInformation
         [JsonProperty("description")]
         public string Description { get; set; }
 
-        [JsonProperty("toolTips")]
+        [JsonProperty("toolTips", NullValueHandling = NullValueHandling.Ignore)]
         public List<string> ToolTips { get; set; }
 
         public TableFieldInformaton()

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/Workspace/SymbolsInformation/TableInformation.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/Workspace/SymbolsInformation/TableInformation.cs
@@ -2,18 +2,24 @@
 using System.Collections.Generic;
 using System.Text;
 using AnZwDev.ALTools.ALSymbolReferences;
+using Newtonsoft.Json;
 
 namespace AnZwDev.ALTools.Workspace.SymbolsInformation
 {
     public class TableInformation : BaseObjectInformation
     {
 
+        [JsonProperty("id", NullValueHandling = NullValueHandling.Ignore)]
+        public List<TableFieldInformaton> Fields { get; set; }
+
         public TableInformation()
         {
+            this.Fields = null;
         }
 
         public TableInformation(ALAppTable table): base(table)
         {
+            this.Fields = null;
         }
 
 

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/Workspace/SymbolsInformation/TableInformationProvider.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/Workspace/SymbolsInformation/TableInformationProvider.cs
@@ -100,7 +100,7 @@ namespace AnZwDev.ALTools.Workspace.SymbolsInformation
 
         #region Get table fields
 
-        public List<TableFieldInformaton> GetTableFields(ALProject project, string tableName, bool includeDisabled, bool includeObsolete, bool includeNormal, bool includeFlowFields, bool includeFlowFilters, bool includeToolTips)
+        public List<TableFieldInformaton> GetTableFields(ALProject project, string tableName, bool includeDisabled, bool includeObsolete, bool includeNormal, bool includeFlowFields, bool includeFlowFilters, bool includeToolTips, IEnumerable<string> toolTipsSourceDependencies)
         {
             List<TableFieldInformaton> fields = new List<TableFieldInformaton>();
 
@@ -132,7 +132,7 @@ namespace AnZwDev.ALTools.Workspace.SymbolsInformation
             {
                 PageInformationProvider pageInformationProvider = new PageInformationProvider();
                 string[] tables = { tableName };
-                Dictionary<string, Dictionary<string, List<string>>> toolTips = pageInformationProvider.CollectTableFieldsToolTips(project, tables, null);
+                Dictionary<string, Dictionary<string, List<string>>> toolTips = pageInformationProvider.CollectTableFieldsToolTips(project, tables, toolTipsSourceDependencies);
                 string tableKey = tableName.ToLower();
                 if (toolTips.ContainsKey(tableKey))
                 {

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/Workspace/SymbolsInformation/XmlPortInformationProvider.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/Workspace/SymbolsInformation/XmlPortInformationProvider.cs
@@ -105,7 +105,7 @@ namespace AnZwDev.ALTools.Workspace.SymbolsInformation
             if ((!String.IsNullOrWhiteSpace(tableElementInformation.Source)) && (getExistingFields || getAvailableFields))
             {
                 TableInformationProvider tableInformationProvider = new TableInformationProvider();
-                List<TableFieldInformaton> allTableFieldsList = tableInformationProvider.GetTableFields(project, tableElementInformation.Source, false, false, true, true, false, false);
+                List<TableFieldInformaton> allTableFieldsList = tableInformationProvider.GetTableFields(project, tableElementInformation.Source, false, false, true, true, false, false, null);
 
                 Dictionary<string, TableFieldInformaton> availableTableFieldsDict = allTableFieldsList.ToDictionary();
                 List<TableFieldInformaton> xmlPortTableFields = new List<TableFieldInformaton>();

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/Workspace/SymbolsInformation/XmlPortInformationProvider.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/Workspace/SymbolsInformation/XmlPortInformationProvider.cs
@@ -105,7 +105,7 @@ namespace AnZwDev.ALTools.Workspace.SymbolsInformation
             if ((!String.IsNullOrWhiteSpace(tableElementInformation.Source)) && (getExistingFields || getAvailableFields))
             {
                 TableInformationProvider tableInformationProvider = new TableInformationProvider();
-                List<TableFieldInformaton> allTableFieldsList = tableInformationProvider.GetTableFields(project, tableElementInformation.Source, false, false, true, true, false);
+                List<TableFieldInformaton> allTableFieldsList = tableInformationProvider.GetTableFields(project, tableElementInformation.Source, false, false, true, true, false, false);
 
                 Dictionary<string, TableFieldInformaton> availableTableFieldsDict = allTableFieldsList.ToDictionary();
                 List<TableFieldInformaton> xmlPortTableFields = new List<TableFieldInformaton>();

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/WorkspaceCommands/AddToolTipsWorkspaceCommand.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/WorkspaceCommands/AddToolTipsWorkspaceCommand.cs
@@ -17,6 +17,8 @@ namespace AnZwDev.ALTools.WorkspaceCommands
         public static string FieldTooltipCommentParameterName = "toolTipFieldComment";
         public static string ActionTooltipParameterName = "toolTipAction";
         public static string UseFieldDescriptionParameterName = "useFieldDescription";
+        public static string ReuseToolTipsParameterName = "reuseToolTips";
+        public static string DependencyNameParameterName = "toolTipDependency";
 
         public AddToolTipsWorkspaceCommand(ALDevToolsServer alDevToolsServer) : base(alDevToolsServer, "addToolTips")
         {
@@ -30,10 +32,21 @@ namespace AnZwDev.ALTools.WorkspaceCommands
             this.SyntaxRewriter.PageFieldTooltipComment = parameters.GetStringValue(FieldTooltipCommentParameterName);
             this.SyntaxRewriter.UseFieldDescription = parameters.GetBoolValue(UseFieldDescriptionParameterName);
 
-            if (this.SyntaxRewriter.Project?.Symbols?.Tables != null)
+            bool reuseToolTips = parameters.GetBoolValue(ReuseToolTipsParameterName);
+
+            if ((this.SyntaxRewriter.Project?.Symbols?.Tables != null) && (reuseToolTips))
             {
+                List<string> toolTipDependencies = new List<string>();
+                foreach (string key in parameters.Keys)
+                {
+                    if ((key.StartsWith(DependencyNameParameterName)) && (!String.IsNullOrWhiteSpace(parameters[key])))
+                        toolTipDependencies.Add(parameters[key]);
+                }
+                if (toolTipDependencies.Count == 0)
+                    toolTipDependencies = null;
+
                 PageInformationProvider provider = new PageInformationProvider();
-                this.SyntaxRewriter.ToolTipsCache = provider.CollectProjectTableFieldsToolTips(this.SyntaxRewriter.Project, null);
+                this.SyntaxRewriter.ToolTipsCache = provider.CollectProjectTableFieldsToolTips(this.SyntaxRewriter.Project, toolTipDependencies);
             }
         }
 

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/WorkspaceCommands/AddToolTipsWorkspaceCommand.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/WorkspaceCommands/AddToolTipsWorkspaceCommand.cs
@@ -1,6 +1,8 @@
 ﻿using AnZwDev.ALTools.ALSymbols;
 using AnZwDev.ALTools.CodeTransformations;
 using AnZwDev.ALTools.Extensions;
+using AnZwDev.ALTools.Workspace;
+using AnZwDev.ALTools.Workspace.SymbolsInformation;
 using Microsoft.Dynamics.Nav.CodeAnalysis;
 using System;
 using System.Collections.Generic;
@@ -27,6 +29,18 @@ namespace AnZwDev.ALTools.WorkspaceCommands
             this.SyntaxRewriter.PageActionTooltip = parameters.GetStringValue(ActionTooltipParameterName);
             this.SyntaxRewriter.PageFieldTooltipComment = parameters.GetStringValue(FieldTooltipCommentParameterName);
             this.SyntaxRewriter.UseFieldDescription = parameters.GetBoolValue(UseFieldDescriptionParameterName);
+
+            if (this.SyntaxRewriter.Project?.Symbols?.Tables != null)
+            {
+                PageInformationProvider provider = new PageInformationProvider();
+                this.SyntaxRewriter.ToolTipsCache = provider.CollectProjectTableFieldsToolTips(this.SyntaxRewriter.Project, null);
+            }
+        }
+
+        protected override void ClearParameters()
+        {
+            base.ClearParameters();
+            this.SyntaxRewriter.ToolTipsCache = null;
         }
 
     }

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/WorkspaceCommands/FormatDocumentWorkspaceCommand.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/WorkspaceCommands/FormatDocumentWorkspaceCommand.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using AnZwDev.ALTools.ALSymbols;
+using System;
 using System.Collections.Generic;
 using System.Text;
 
@@ -10,6 +11,15 @@ namespace AnZwDev.ALTools.WorkspaceCommands
         public FormatDocumentWorkspaceCommand(ALDevToolsServer alDevToolsServer) : base(alDevToolsServer, "formatDocument")
         {
         }
+
+        public override WorkspaceCommandResult Run(string sourceCode, string projectPath, string filePath, Range range, Dictionary<string, string> parameters)
+        {
+            WorkspaceCommandResult result = base.Run(sourceCode, projectPath, filePath, range, parameters);
+            result.SetParameter(NoOfChangesParameterName, "");
+            result.SetParameter(NoOfChangedFilesParameterName, "");
+            return result;
+        }
+
 
     }
 }

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/WorkspaceCommands/FormatDocumentWorkspaceCommand.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/WorkspaceCommands/FormatDocumentWorkspaceCommand.cs
@@ -1,4 +1,5 @@
 ﻿using AnZwDev.ALTools.ALSymbols;
+using Microsoft.Dynamics.Nav.CodeAnalysis;
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -20,6 +21,10 @@ namespace AnZwDev.ALTools.WorkspaceCommands
             return result;
         }
 
+        public override SyntaxNode ProcessSyntaxNode(SyntaxNode node, string sourceCode, string projectPath, string filePath, TextSpan span, Dictionary<string, string> parameters)
+        {
+            return FormatSyntaxNode(node);
+        }
 
     }
 }

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/WorkspaceCommands/FormatDocumentWorkspaceCommand.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/WorkspaceCommands/FormatDocumentWorkspaceCommand.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace AnZwDev.ALTools.WorkspaceCommands
+{
+    public class FormatDocumentWorkspaceCommand : SyntaxTreeWorkspaceCommand
+    {
+
+        public FormatDocumentWorkspaceCommand(ALDevToolsServer alDevToolsServer) : base(alDevToolsServer, "formatDocument")
+        {
+        }
+
+    }
+}

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/WorkspaceCommands/LockRemovedFieldsCaptionsWorkspaceCommand.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/WorkspaceCommands/LockRemovedFieldsCaptionsWorkspaceCommand.cs
@@ -1,0 +1,16 @@
+﻿using AnZwDev.ALTools.CodeTransformations;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace AnZwDev.ALTools.WorkspaceCommands
+{
+    public class LockRemovedFieldsCaptionsWorkspaceCommand : SyntaxRewriterWorkspaceCommand<LockRemovedFieldsCaptionsSyntaxRewriter>
+    {
+
+        public LockRemovedFieldsCaptionsWorkspaceCommand(ALDevToolsServer alDevToolsServer) : base(alDevToolsServer, "lockRemovedFieldsCaptions")
+        {
+        }
+
+    }
+}

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/WorkspaceCommands/RefreshToolTipsWorkspaceCommand.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/WorkspaceCommands/RefreshToolTipsWorkspaceCommand.cs
@@ -16,6 +16,7 @@ namespace AnZwDev.ALTools.WorkspaceCommands
 
         protected override void SetParameters(string sourceCode, string projectPath, string filePath, TextSpan span, Dictionary<string, string> parameters)
         {
+            base.SetParameters(sourceCode, projectPath, filePath, span, parameters);
             if (this.SyntaxRewriter.Project?.Symbols?.Tables != null)
             {
                 //collect list of dependencies
@@ -29,7 +30,6 @@ namespace AnZwDev.ALTools.WorkspaceCommands
                 PageInformationProvider provider = new PageInformationProvider();
                 this.SyntaxRewriter.ToolTipsCache = provider.CollectProjectTableFieldsToolTips(this.SyntaxRewriter.Project, dependencies);
             }
-            base.SetParameters(sourceCode, projectPath, filePath, span, parameters);
         }
 
         protected override void ClearParameters()

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/WorkspaceCommands/RefreshToolTipsWorkspaceCommand.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/WorkspaceCommands/RefreshToolTipsWorkspaceCommand.cs
@@ -1,0 +1,42 @@
+﻿using AnZwDev.ALTools.CodeTransformations;
+using AnZwDev.ALTools.Workspace.SymbolsInformation;
+using Microsoft.Dynamics.Nav.CodeAnalysis;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace AnZwDev.ALTools.WorkspaceCommands
+{
+    public class RefreshToolTipsWorkspaceCommand : SyntaxRewriterWorkspaceCommand<RefreshToolTipsSyntaxRewriter>
+    {
+
+        public RefreshToolTipsWorkspaceCommand(ALDevToolsServer alDevToolsServer) : base(alDevToolsServer, "refreshToolTips")
+        {
+        }
+
+        protected override void SetParameters(string sourceCode, string projectPath, string filePath, TextSpan span, Dictionary<string, string> parameters)
+        {
+            if (this.SyntaxRewriter.Project?.Symbols?.Tables != null)
+            {
+                //collect list of dependencies
+                List<string> dependencies = new List<string>();
+                foreach (string parameterName in parameters.Keys)
+                    if (parameterName.StartsWith("dependencyName"))
+                        dependencies.Add(parameters[parameterName]);
+                if (dependencies.Count == 0)
+                    dependencies = null;
+                //collect tooltips
+                PageInformationProvider provider = new PageInformationProvider();
+                this.SyntaxRewriter.ToolTipsCache = provider.CollectProjectTableFieldsToolTips(this.SyntaxRewriter.Project, dependencies);
+            }
+            base.SetParameters(sourceCode, projectPath, filePath, span, parameters);
+        }
+
+        protected override void ClearParameters()
+        {
+            this.SyntaxRewriter.ToolTipsCache = null;
+            base.ClearParameters();
+        }
+
+    }
+}

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/WorkspaceCommands/RemoveBeginEndWorkspaceCommand.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/WorkspaceCommands/RemoveBeginEndWorkspaceCommand.cs
@@ -1,0 +1,16 @@
+﻿using AnZwDev.ALTools.CodeTransformations;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace AnZwDev.ALTools.WorkspaceCommands
+{
+    public class RemoveBeginEndWorkspaceCommandd : SyntaxRewriterWorkspaceCommand<RemoveBeginEndSyntaxRewriter>
+    {
+
+        public RemoveBeginEndWorkspaceCommandd(ALDevToolsServer alDevToolsServer) : base(alDevToolsServer, "removeBeginEnd")
+        {
+        }
+
+    }
+}

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/WorkspaceCommands/SemanticModelWorkspaceCommand.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/WorkspaceCommands/SemanticModelWorkspaceCommand.cs
@@ -1,4 +1,5 @@
 ﻿using AnZwDev.ALTools.ALSymbols;
+using AnZwDev.ALTools.Core;
 using AnZwDev.ALTools.Logging;
 using AnZwDev.ALTools.SourceControl;
 using AnZwDev.ALTools.Workspace;
@@ -53,7 +54,7 @@ namespace AnZwDev.ALTools.WorkspaceCommands
             return new WorkspaceCommandResult(newSourceCode, true, errorMessage);
         }
 
-        #region Project loading
+    #region Project loading
 
         protected Compilation LoadProject(string projectPath, List<SyntaxTree> syntaxTrees, string sourceCode, string sourcePath, out SyntaxTree sourceSyntaxTree)
         {
@@ -65,7 +66,7 @@ namespace AnZwDev.ALTools.WorkspaceCommands
 
             //load project manifest
             string projectFile = Path.Combine(projectPath, "app.json");
-            ProjectManifest manifest = ProjectManifest.ReadFromString(projectFile, File.ReadAllText(projectFile), diagnostics);
+            ProjectManifest manifest = ProjectManifest.ReadFromString(projectFile, FileUtils.SafeReadAllText(projectFile), diagnostics);
 
             //create compilation
             Compilation compilation = Compilation.Create("MyCompilation", manifest.AppManifest.AppPublisher,
@@ -113,7 +114,7 @@ namespace AnZwDev.ALTools.WorkspaceCommands
                 if (sourceFile)
                     content = sourceCode;
                 else
-                    content = File.ReadAllText(filePaths[i]);
+                    content = FileUtils.SafeReadAllText(filePaths[i]);
                 SyntaxTree syntaxTree = SyntaxTree.ParseObjectText(content, filePaths[i]);
                 syntaxTrees.Add(syntaxTree);
 
@@ -123,9 +124,9 @@ namespace AnZwDev.ALTools.WorkspaceCommands
         }
 
 
-        #endregion
+    #endregion
 
-        #region Project files processing
+    #region Project files processing
 
         protected bool ValidFile(string filePath)
         {
@@ -201,7 +202,7 @@ namespace AnZwDev.ALTools.WorkspaceCommands
             return node;
         }
 
-        #endregion
+    #endregion
 
     }
 #endif

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/WorkspaceCommands/SetPageFieldToolTipWorkspaceCommand.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/WorkspaceCommands/SetPageFieldToolTipWorkspaceCommand.cs
@@ -1,0 +1,26 @@
+﻿using AnZwDev.ALTools.CodeTransformations;
+using AnZwDev.ALTools.Extensions;
+using AnZwDev.ALTools.Workspace.SymbolsInformation;
+using Microsoft.Dynamics.Nav.CodeAnalysis;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace AnZwDev.ALTools.WorkspaceCommands
+{
+    public class SetPageFieldToolTipWorkspaceCommand : SyntaxRewriterWorkspaceCommand<SetPageFieldToolTipSyntaxRewriter>
+    {
+        public static string ToolTipParameterName = "toolTip";
+
+        public SetPageFieldToolTipWorkspaceCommand(ALDevToolsServer alDevToolsServer) : base(alDevToolsServer, "setPageFieldToolTip")
+        {
+        }
+
+        protected override void SetParameters(string sourceCode, string projectPath, string filePath, TextSpan span, Dictionary<string, string> parameters)
+        {
+            base.SetParameters(sourceCode, projectPath, filePath, span, parameters);
+            this.SyntaxRewriter.ToolTip = parameters.GetStringValue(ToolTipParameterName);
+        }
+
+    }
+}

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/WorkspaceCommands/SourceTextWorkspaceCommand.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/WorkspaceCommands/SourceTextWorkspaceCommand.cs
@@ -1,4 +1,5 @@
 ﻿using AnZwDev.ALTools.ALSymbols;
+using AnZwDev.ALTools.Core;
 using AnZwDev.ALTools.SourceControl;
 using System;
 using System.Collections.Generic;
@@ -62,7 +63,7 @@ namespace AnZwDev.ALTools.WorkspaceCommands
 
         protected virtual (bool, string) ProcessFile(string projectPath, string filePath, Dictionary<string, string> parameters)
         {
-            string source = System.IO.File.ReadAllText(filePath);
+            string source = FileUtils.SafeReadAllText(filePath);
             (string newSource, bool success, string errorMessage) = this.ProcessSourceCode(source, projectPath, filePath, null, parameters);
             if ((success) && (newSource != source) && (!String.IsNullOrWhiteSpace(newSource)))
                 System.IO.File.WriteAllText(filePath, newSource);

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/WorkspaceCommands/SourceTextWorkspaceCommand.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/WorkspaceCommands/SourceTextWorkspaceCommand.cs
@@ -1,0 +1,65 @@
+﻿using AnZwDev.ALTools.ALSymbols;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace AnZwDev.ALTools.WorkspaceCommands
+{
+    public class SourceTextWorkspaceCommand : WorkspaceCommand
+    {
+
+        public SourceTextWorkspaceCommand(ALDevToolsServer alDevToolsServer, string name) : base(alDevToolsServer, name)
+        {
+        }
+
+        public override WorkspaceCommandResult Run(string sourceCode, string projectPath, string filePath, Range range, Dictionary<string, string> parameters)
+        {
+            string newSourceCode = null;
+            bool success = true;
+            string errorMessage = null;
+
+            if (!String.IsNullOrWhiteSpace(filePath))
+            {
+                if (!String.IsNullOrEmpty(sourceCode))
+                {
+                    (newSourceCode, success, errorMessage) = this.ProcessSourceCode(sourceCode, projectPath, filePath, range, parameters);
+                    if (!success)
+                        return new WorkspaceCommandResult(newSourceCode, true, errorMessage);
+                }
+            }
+            else if (!String.IsNullOrWhiteSpace(projectPath))
+                (success, errorMessage) = this.ProcessDirectory(projectPath, parameters);
+
+            if (success)
+                return new WorkspaceCommandResult(newSourceCode);
+            return new WorkspaceCommandResult(newSourceCode, true, errorMessage);
+        }
+
+        protected virtual (string, bool, string) ProcessSourceCode(string sourceCode, string projectPath, string filePath, Range range, Dictionary<string, string> parameters)
+        {
+            return (sourceCode, true, null);
+        }
+
+        protected virtual (bool, string) ProcessDirectory(string projectPath, Dictionary<string, string> parameters)
+        {
+            string[] filePathsList = System.IO.Directory.GetFiles(projectPath, "*.al", System.IO.SearchOption.AllDirectories);
+            for (int i = 0; i < filePathsList.Length; i++)
+            {
+                (bool success, string errorMessage) = this.ProcessFile(projectPath, filePathsList[i], parameters);
+                if (!success)
+                    return (false, errorMessage);
+            }
+            return (true, null);
+        }
+
+        protected virtual (bool, string) ProcessFile(string projectPath, string filePath, Dictionary<string, string> parameters)
+        {
+            string source = System.IO.File.ReadAllText(filePath);
+            (string newSource, bool success, string errorMessage) = this.ProcessSourceCode(source, projectPath, filePath, null, parameters);
+            if ((success) && (newSource != source) && (!String.IsNullOrWhiteSpace(newSource)))
+                System.IO.File.WriteAllText(filePath, newSource);
+            return (success, errorMessage);
+        }
+
+    }
+}

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/WorkspaceCommands/SourceTextWorkspaceCommand.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/WorkspaceCommands/SourceTextWorkspaceCommand.cs
@@ -1,4 +1,5 @@
 ﻿using AnZwDev.ALTools.ALSymbols;
+using AnZwDev.ALTools.SourceControl;
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -42,7 +43,14 @@ namespace AnZwDev.ALTools.WorkspaceCommands
 
         protected virtual (bool, string) ProcessDirectory(string projectPath, Dictionary<string, string> parameters)
         {
-            string[] filePathsList = System.IO.Directory.GetFiles(projectPath, "*.al", System.IO.SearchOption.AllDirectories);
+            string[] filePathsList;
+
+            bool modifiedFilesOnly = this.GetModifiedFilesOnlyValue(parameters);
+            if (modifiedFilesOnly)
+                filePathsList = this.ModifiedFilesNamesList;
+            else
+                filePathsList = System.IO.Directory.GetFiles(projectPath, "*.al", System.IO.SearchOption.AllDirectories);
+
             for (int i = 0; i < filePathsList.Length; i++)
             {
                 (bool success, string errorMessage) = this.ProcessFile(projectPath, filePathsList[i], parameters);

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/WorkspaceCommands/SyntaxTreeWorkspaceCommand.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/WorkspaceCommands/SyntaxTreeWorkspaceCommand.cs
@@ -9,13 +9,14 @@ using System.Collections.Generic;
 
 namespace AnZwDev.ALTools.WorkspaceCommands
 {
-    public class SyntaxTreeWorkspaceCommand : WorkspaceCommand
+    public class SyntaxTreeWorkspaceCommand : SourceTextWorkspaceCommand
     {
 
         public SyntaxTreeWorkspaceCommand(ALDevToolsServer alDevToolsServer, string name) : base(alDevToolsServer, name)
         {
         }
 
+        /*
         public override WorkspaceCommandResult Run(string sourceCode, string projectPath, string filePath, Range range, Dictionary<string, string> parameters)
         {
             string newSourceCode = null;
@@ -38,8 +39,9 @@ namespace AnZwDev.ALTools.WorkspaceCommands
                 return new WorkspaceCommandResult(newSourceCode);
             return new WorkspaceCommandResult(newSourceCode, true, errorMessage);
         }
+        */
 
-        protected (string, bool, string) ProcessSourceCode(string sourceCode, string projectPath, string filePath, Range range, Dictionary<string, string> parameters)
+        protected override (string, bool, string) ProcessSourceCode(string sourceCode, string projectPath, string filePath, Range range, Dictionary<string, string> parameters)
         {
             try
             {
@@ -74,6 +76,7 @@ namespace AnZwDev.ALTools.WorkspaceCommands
             }
         }
 
+        /*
         protected virtual (bool, string) ProcessDirectory(string projectPath, Dictionary<string, string> parameters)
         {
             string[] filePathsList = System.IO.Directory.GetFiles(projectPath, "*.al", System.IO.SearchOption.AllDirectories);
@@ -94,6 +97,7 @@ namespace AnZwDev.ALTools.WorkspaceCommands
                 System.IO.File.WriteAllText(filePath, newSource);
             return (success, errorMessage);
         }
+        */
 
         public virtual SyntaxNode ProcessSyntaxNode(SyntaxNode node, string sourceCode, string projectPath, string filePath, TextSpan span, Dictionary<string, string> parameters)
         {

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/WorkspaceCommands/SyntaxTreeWorkspaceCommand.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/WorkspaceCommands/SyntaxTreeWorkspaceCommand.cs
@@ -91,7 +91,7 @@ namespace AnZwDev.ALTools.WorkspaceCommands
 
         protected virtual (bool, string) ProcessFile(string projectPath, string filePath, Dictionary<string, string> parameters)
         {
-            string source = System.IO.File.ReadAllText(filePath);
+            string source = FileUtils.SafeReadAllText(filePath);
             (string newSource, bool success, string errorMessage) = this.ProcessSourceCode(source, projectPath, filePath, null, parameters);
             if ((success) && (newSource != source) && (!String.IsNullOrWhiteSpace(newSource)))
                 System.IO.File.WriteAllText(filePath, newSource);

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/WorkspaceCommands/TrimTrailingWhitespaceWorkspaceCommand.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/WorkspaceCommands/TrimTrailingWhitespaceWorkspaceCommand.cs
@@ -1,0 +1,24 @@
+﻿using AnZwDev.ALTools.ALSymbols;
+using AnZwDev.ALTools.Extensions;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace AnZwDev.ALTools.WorkspaceCommands
+{
+    public class TrimTrailingWhitespaceWorkspaceCommand : SourceTextWorkspaceCommand
+    {
+
+        public TrimTrailingWhitespaceWorkspaceCommand(ALDevToolsServer alDevToolsServer) : base(alDevToolsServer, "trimTrailingWhitespace")
+        {
+        }
+
+        protected override (string, bool, string) ProcessSourceCode(string sourceCode, string projectPath, string filePath, Range range, Dictionary<string, string> parameters)
+        {
+            sourceCode = sourceCode.MultilineTrimEnd();
+            return (sourceCode, true, null);
+        }
+
+
+    }
+}

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/WorkspaceCommands/TrimTrailingWhitespaceWorkspaceCommand.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/WorkspaceCommands/TrimTrailingWhitespaceWorkspaceCommand.cs
@@ -8,6 +8,8 @@ namespace AnZwDev.ALTools.WorkspaceCommands
 {
     public class TrimTrailingWhitespaceWorkspaceCommand : SourceTextWorkspaceCommand
     {
+        protected int _totalNoOfChanges = 0;
+        protected int _noOfChangedFiles = 0;
 
         public TrimTrailingWhitespaceWorkspaceCommand(ALDevToolsServer alDevToolsServer) : base(alDevToolsServer, "trimTrailingWhitespace")
         {
@@ -15,10 +17,28 @@ namespace AnZwDev.ALTools.WorkspaceCommands
 
         protected override (string, bool, string) ProcessSourceCode(string sourceCode, string projectPath, string filePath, Range range, Dictionary<string, string> parameters)
         {
-            sourceCode = sourceCode.MultilineTrimEnd();
-            return (sourceCode, true, null);
+            string newSourceCode = sourceCode.MultilineTrimEnd();
+
+            if (newSourceCode != sourceCode)
+            {
+                _totalNoOfChanges++;
+                _noOfChangedFiles++;
+            }
+
+            return (newSourceCode, true, null);
         }
 
+        public override WorkspaceCommandResult Run(string sourceCode, string projectPath, string filePath, Range range, Dictionary<string, string> parameters)
+        {
+            this._totalNoOfChanges = 0;
+            this._noOfChangedFiles = 0;
+
+            WorkspaceCommandResult result = base.Run(sourceCode, projectPath, filePath, range, parameters);
+
+            result.SetParameter(NoOfChangesParameterName, this._totalNoOfChanges.ToString());
+            result.SetParameter(NoOfChangedFilesParameterName, this._noOfChangedFiles.ToString());
+            return result;
+        }
 
     }
 }

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/WorkspaceCommands/WorkspaceCommand.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/WorkspaceCommands/WorkspaceCommand.cs
@@ -1,4 +1,5 @@
 ﻿using AnZwDev.ALTools.ALSymbols;
+using AnZwDev.ALTools.SourceControl;
 using Microsoft.Dynamics.Nav.CodeAnalysis;
 #if BC
 using Microsoft.Dynamics.Nav.CodeAnalysis.Workspaces.Formatting;
@@ -18,10 +19,43 @@ namespace AnZwDev.ALTools.WorkspaceCommands
         public ALDevToolsServer ALDevToolsServer { get; }
         public string Name { get; set; }
 
+        protected string[] ModifiedFilesNamesList { get; set; }
+        protected HashSet<string> ModifiedFilesNamesHashSet { get; set; }
+
         public WorkspaceCommand(ALDevToolsServer alDevToolsServer, string newName)
         {
             this.ALDevToolsServer = alDevToolsServer;
             this.Name = newName;
+            this.ModifiedFilesNamesList = null;
+            this.ModifiedFilesNamesHashSet = null;
+        }
+
+        public virtual (WorkspaceCommandResult, bool) CanRun(string sourceCode, string projectPath, string filePath, Range range, Dictionary<string, string> parameters)
+        {
+            bool modifiedFilesOnly = this.GetModifiedFilesOnlyValue(parameters);
+            if (modifiedFilesOnly)
+            {
+                try
+                {
+                    this.ModifiedFilesNamesList = GitClient.GetModifiedFiles(projectPath, ".al");
+                    this.ModifiedFilesNamesHashSet = new HashSet<string>();
+                    foreach (string name in this.ModifiedFilesNamesList)
+                        this.ModifiedFilesNamesHashSet.Add(name);
+                }
+                catch (Exception ex)
+                {
+                    return (
+                        new WorkspaceCommandResult("SourceControl", true, ex.Message),
+                        false);
+                }
+            }
+            else
+            {
+                this.ModifiedFilesNamesList = null;
+                this.ModifiedFilesNamesHashSet = null;
+            }
+
+            return (null, true);
         }
 
         public virtual WorkspaceCommandResult Run(string sourceCode, string projectPath, string filePath, Range range, Dictionary<string, string> parameters)
@@ -40,7 +74,6 @@ namespace AnZwDev.ALTools.WorkspaceCommands
 #endif
         }
 
-
 #if BC
         private Microsoft.Dynamics.Nav.EditorServices.Protocol.VsCodeWorkspace _workspace = null;
         protected Microsoft.Dynamics.Nav.EditorServices.Protocol.VsCodeWorkspace GetWorkspace()
@@ -51,6 +84,25 @@ namespace AnZwDev.ALTools.WorkspaceCommands
             return this._workspace;
         }
 #endif
+
+
+        protected bool GetSkipFormattingValue(Dictionary<string, string> parameters)
+        {
+            return (
+                (parameters != null) && 
+                (parameters.ContainsKey("skipFormatting")) && 
+                (parameters["skipFormatting"] != null) &&
+                (parameters["skipFormatting"].Equals("true", StringComparison.CurrentCultureIgnoreCase)));
+        }
+
+        protected bool GetModifiedFilesOnlyValue(Dictionary<string, string> parameters)
+        {
+            return (
+                (parameters != null) &&
+                (parameters.ContainsKey("modifiedFilesOnly")) &&
+                (parameters["modifiedFilesOnly"] != null) &&
+                (parameters["modifiedFilesOnly"].Equals("true", StringComparison.CurrentCultureIgnoreCase)));
+        }
 
     }
 }

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/WorkspaceCommands/WorkspaceCommandsManager.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/WorkspaceCommands/WorkspaceCommandsManager.cs
@@ -51,6 +51,7 @@ namespace AnZwDev.ALTools.WorkspaceCommands
 #endif
             this.RegisterCommand(new RemoveVariableWorkspaceCommand(this.ALDevToolsServer));
             this.RegisterCommand(new ConvertObjectIdsToNamesWorkspaceCommand(this.ALDevToolsServer));
+            this.RegisterCommand(new RemoveBeginEndWorkspaceCommandd(this.ALDevToolsServer));
 
             this.RegisterCommand(new FormatDocumentWorkspaceCommand(this.ALDevToolsServer));
 

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/WorkspaceCommands/WorkspaceCommandsManager.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/WorkspaceCommands/WorkspaceCommandsManager.cs
@@ -53,8 +53,6 @@ namespace AnZwDev.ALTools.WorkspaceCommands
             this.RegisterCommand(new ConvertObjectIdsToNamesWorkspaceCommand(this.ALDevToolsServer));
             this.RegisterCommand(new RemoveBeginEndWorkspaceCommandd(this.ALDevToolsServer));
 
-            this.RegisterCommand(new FormatDocumentWorkspaceCommand(this.ALDevToolsServer));
-
             this.RegisterCommand(groupCommand.AddCommand(new SortProceduresWorkspaceCommand(this.ALDevToolsServer)));
             this.RegisterCommand(groupCommand.AddCommand(new SortVariablesWorkspaceCommand(this.ALDevToolsServer)));
             this.RegisterCommand(groupCommand.AddCommand(new SortPropertiesWorkspaceCommand(this.ALDevToolsServer)));
@@ -62,6 +60,7 @@ namespace AnZwDev.ALTools.WorkspaceCommands
             this.RegisterCommand(groupCommand.AddCommand(new SortTableFieldsWorkspaceCommand(this.ALDevToolsServer)));
             this.RegisterCommand(groupCommand.AddCommand(new SortPermissionsWorkspaceCommand(this.ALDevToolsServer)));
             this.RegisterCommand(groupCommand.AddCommand(new SortPermissionSetListWorkspaceCommand(this.ALDevToolsServer)));
+            this.RegisterCommand(groupCommand.AddCommand(new FormatDocumentWorkspaceCommand(this.ALDevToolsServer)));
 
             this.RegisterCommand(groupCommand);
         }

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/WorkspaceCommands/WorkspaceCommandsManager.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/WorkspaceCommands/WorkspaceCommandsManager.cs
@@ -33,6 +33,7 @@ namespace AnZwDev.ALTools.WorkspaceCommands
             this.RegisterCommand(new AddAppAreasWorkspaceCommand(this.ALDevToolsServer));
             this.RegisterCommand(new AddToolTipsWorkspaceCommand(this.ALDevToolsServer));
             this.RegisterCommand(new RefreshToolTipsWorkspaceCommand(this.ALDevToolsServer));
+            this.RegisterCommand(new SetPageFieldToolTipWorkspaceCommand(this.ALDevToolsServer));
             this.RegisterCommand(new AddPageControlCaptionWorkspaceCommand(this.ALDevToolsServer));
             this.RegisterCommand(new AddDataClassificationWorkspaceCommand(this.ALDevToolsServer));
             this.RegisterCommand(new AddFieldCaptionsWorkspaceCommand(this.ALDevToolsServer));

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/WorkspaceCommands/WorkspaceCommandsManager.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/WorkspaceCommands/WorkspaceCommandsManager.cs
@@ -32,6 +32,7 @@ namespace AnZwDev.ALTools.WorkspaceCommands
 
             this.RegisterCommand(new AddAppAreasWorkspaceCommand(this.ALDevToolsServer));
             this.RegisterCommand(new AddToolTipsWorkspaceCommand(this.ALDevToolsServer));
+            this.RegisterCommand(new RefreshToolTipsWorkspaceCommand(this.ALDevToolsServer));
             this.RegisterCommand(new AddPageControlCaptionWorkspaceCommand(this.ALDevToolsServer));
             this.RegisterCommand(new AddDataClassificationWorkspaceCommand(this.ALDevToolsServer));
             this.RegisterCommand(new AddFieldCaptionsWorkspaceCommand(this.ALDevToolsServer));

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/WorkspaceCommands/WorkspaceCommandsManager.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/WorkspaceCommands/WorkspaceCommandsManager.cs
@@ -35,11 +35,13 @@ namespace AnZwDev.ALTools.WorkspaceCommands
             this.RegisterCommand(new AddPageControlCaptionWorkspaceCommand(this.ALDevToolsServer));
             this.RegisterCommand(new AddDataClassificationWorkspaceCommand(this.ALDevToolsServer));
             this.RegisterCommand(new AddFieldCaptionsWorkspaceCommand(this.ALDevToolsServer));
+            this.RegisterCommand(new LockRemovedFieldsCaptionsWorkspaceCommand(this.ALDevToolsServer));
             this.RegisterCommand(new AddObjectCaptionsWorkspaceCommand(this.ALDevToolsServer));
 
             this.RegisterCommand(new FixKeywordsCaseWorkspaceCommand(this.ALDevToolsServer));
 
             this.RegisterCommand(new AddObjectsPermissionsWorkspaceCommand(this.ALDevToolsServer));
+            this.RegisterCommand(new TrimTrailingWhitespaceWorkspaceCommand(this.ALDevToolsServer));
 
 #if BC            
             this.RegisterCommand(new RemoveWithWorkspaceCommand(this.ALDevToolsServer));
@@ -49,6 +51,8 @@ namespace AnZwDev.ALTools.WorkspaceCommands
 #endif
             this.RegisterCommand(new RemoveVariableWorkspaceCommand(this.ALDevToolsServer));
             this.RegisterCommand(new ConvertObjectIdsToNamesWorkspaceCommand(this.ALDevToolsServer));
+
+            this.RegisterCommand(new FormatDocumentWorkspaceCommand(this.ALDevToolsServer));
 
             this.RegisterCommand(groupCommand.AddCommand(new SortProceduresWorkspaceCommand(this.ALDevToolsServer)));
             this.RegisterCommand(groupCommand.AddCommand(new SortVariablesWorkspaceCommand(this.ALDevToolsServer)));

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/WorkspaceCommands/WorkspaceCommandsManager.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/WorkspaceCommands/WorkspaceCommandsManager.cs
@@ -68,7 +68,13 @@ namespace AnZwDev.ALTools.WorkspaceCommands
         public WorkspaceCommandResult RunCommand(string commandName, string sourceCode, string projectPath, string filePath, Range range, Dictionary<string, string> parameters)
         {
             if (_commands.ContainsKey(commandName))
+            {
+                WorkspaceCommand command = _commands[commandName];
+                (WorkspaceCommandResult errorResult, bool canRun) = command.CanRun(sourceCode, projectPath, filePath, range, parameters);
+                if (!canRun)
+                    return errorResult;
                 return _commands[commandName].Run(sourceCode, projectPath, filePath, range, parameters);
+            }
             else
                 throw new Exception($"Workspace command {commandName} not found.");
         }


### PR DESCRIPTION
 - Reuse tooltip from other pages
 - Empty lines at end of new files
 - CodeActionsOnSave is terribly slow (AL <> AL code outline)
 - Symbols Browser - Go to definition (project file or server definition) - shared file access fix
 - New "Code Cleanup" commands for workspace, editor and uncommited only workspace files
 - New "Lock Removed Table Field Captions" commands for workspace and editor
 - Idea: Fix begin..end (AA0005) warnings in project/editor
 - New structure of problems reported by CodeCop was preventing CodeCop code action fixes from running