### PR TITLE
Development

### DIFF
--- a/AZALDevToolsServer/AZALDevToolsTestConsoleApp.NetFramework/Program.cs
+++ b/AZALDevToolsServer/AZALDevToolsTestConsoleApp.NetFramework/Program.cs
@@ -53,7 +53,7 @@ namespace AZALDevToolsTestConsoleApp.NetFramework
             ALProjectSource[] projects =
             {
                 //"C:\\Projects\\Sandboxes\\al-test-projects\\SmallBC16\\"
-                new ALProjectSource("C:\\Projects\\Sandboxes\\al-test-projects\\SmallBC18", null, null)
+                new ALProjectSource("C:\\Projects\\Sandboxes\\al-test-projects\\SmallBC18", null, null, null)
             };
             
 

--- a/AZALDevToolsServer/AZALDevToolsTestConsoleApp/AZALDevToolsTestConsoleApp.csproj
+++ b/AZALDevToolsServer/AZALDevToolsTestConsoleApp/AZALDevToolsTestConsoleApp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/AZALDevToolsServer/AZALDevToolsTestConsoleApp/Program.cs
+++ b/AZALDevToolsServer/AZALDevToolsTestConsoleApp/Program.cs
@@ -66,7 +66,7 @@ namespace AZALDevToolsTestConsoleApp
             host.ALDevToolsServer.Workspace.ResolveDependencies();
 
 
-            DCDuplicateCodeAnalyzer duplicateAnalyzer = new DCDuplicateCodeAnalyzer(3);
+            DCDuplicateCodeAnalyzer duplicateAnalyzer = new DCDuplicateCodeAnalyzer(3, AnZwDev.ALTools.ALSymbols.Internal.ConvertedObsoleteState.None);
             var duplicatesList = duplicateAnalyzer.FindDuplicates(host.ALDevToolsServer.Workspace, null);
 
             //filePath = "C:\\Projects\\Sandboxes\\al-test-projects\\SmallBC18\\Pag50104.MyPrefixMyPageCard.al";

--- a/AZALDevToolsServer/AZALDevToolsTestConsoleApp/Program.cs
+++ b/AZALDevToolsServer/AZALDevToolsTestConsoleApp/Program.cs
@@ -82,7 +82,9 @@ namespace AZALDevToolsTestConsoleApp
             //filePath = "C:\\Projects\\Sandboxes\\al-test-projects\\BC184TestProject\\Rep50100.MyReport.al";
             //filePath = "C:\\Projects\\Sandboxes\\al-test-projects\\BC184TestProject\\MyTable.al";
             //filePath = "C:\\Projects\\Sandboxes\\al-test-projects\\BC184TestProject\\PageEmptySectionsTest.al";
-            filePath = "C:\\Projects\\Sandboxes\\al-test-projects\\BC184TestProject\\WithTestsCU.al";            
+            //filePath = "C:\\Projects\\Sandboxes\\al-test-projects\\BC184TestProject\\WithTestsCU.al";
+
+            filePath = "C:\\Projects\\Sandboxes\\al-test-projects\\BC184TestProject\\Pag50105.MyItem3.al";
 
             string content = FileUtils.SafeReadAllText(filePath);
             Dictionary<string, string> pm = new();
@@ -113,8 +115,9 @@ namespace AZALDevToolsTestConsoleApp
             //WorkspaceCommandResult o = host.ALDevToolsServer.WorkspaceCommandsManager.RunCommand("sortProperties", content, projects[0], filePath, null, pm);
             //WorkspaceCommandResult o = host.ALDevToolsServer.WorkspaceCommandsManager.RunCommand("removeEmptyLines", content, projects[0].folderPath, filePath, null, pm, null);
             //WorkspaceCommandResult o = host.ALDevToolsServer.WorkspaceCommandsManager.RunCommand("removeEmptySections", content, projects[0].folderPath, filePath, null, pm, null);
+            //WorkspaceCommandResult o = host.ALDevToolsServer.WorkspaceCommandsManager.RunCommand("removeStrSubstNoFromError", content, projects[0].folderPath, filePath, null, pm, null);
 
-            WorkspaceCommandResult o = host.ALDevToolsServer.WorkspaceCommandsManager.RunCommand("removeStrSubstNoFromError", content, projects[0].folderPath, filePath, null, pm, null);
+            WorkspaceCommandResult o = host.ALDevToolsServer.WorkspaceCommandsManager.RunCommand("removeRedundantAppAreas", content, projects[0].folderPath, filePath, null, pm, null);
 
 
             ALProject project = host.ALDevToolsServer.Workspace.Projects[0];

--- a/AZALDevToolsServer/AZALDevToolsTestConsoleApp/Program.cs
+++ b/AZALDevToolsServer/AZALDevToolsTestConsoleApp/Program.cs
@@ -59,7 +59,7 @@ namespace AZALDevToolsTestConsoleApp
             //test project
             ALProjectSource[] projects =
             {
-                new ALProjectSource("C:\\Projects\\Sandboxes\\al-test-projects\\BC184TestProject", null, null)
+                new ALProjectSource("C:\\Projects\\Sandboxes\\al-test-projects\\BC184TestProject", null, null, null)
                 //"C:\\Projects\\Sandboxes\\al-test-projects\\SmallBC18"                
             };
             host.ALDevToolsServer.Workspace.LoadProjects(projects);

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools.Server/Contracts/FindDuplicateCodeRequest.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools.Server/Contracts/FindDuplicateCodeRequest.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using AnZwDev.ALTools.ALSymbols.Internal;
+using System;
 using System.Collections.Generic;
 using System.Text;
 
@@ -7,6 +8,7 @@ namespace AnZwDev.ALTools.Server.Contracts
     public class FindDuplicateCodeRequest
     {
         public int minNoOfStatements { get; set; }
+        public ConvertedObsoleteState skipObsoleteCodeLevel { get; set; }
         public string path { get; set; }
     }
 }

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools.Server/Handlers/FindDuplicateCodeRequestHandler.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools.Server/Handlers/FindDuplicateCodeRequestHandler.cs
@@ -22,7 +22,7 @@ namespace AnZwDev.ALTools.Server.Handlers
             FindDuplicateCodeResponse response = new FindDuplicateCodeResponse();
             try
             {
-                DCDuplicateCodeAnalyzer analyzer = new DCDuplicateCodeAnalyzer(parameters.minNoOfStatements);
+                DCDuplicateCodeAnalyzer analyzer = new DCDuplicateCodeAnalyzer(parameters.minNoOfStatements, parameters.skipObsoleteCodeLevel);
                 response.duplicates = analyzer.FindDuplicates(this.Server.Workspace, parameters.path);
             }
             catch (Exception e)

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/ALSymbols/Internal/ConvertedObsoleteState.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/ALSymbols/Internal/ConvertedObsoleteState.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace AnZwDev.ALTools.ALSymbols.Internal
+{
+    public enum ConvertedObsoleteState
+    {
+        None = 0,
+        Pending = 1,
+        Removed = 2
+    }
+}

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/CodeCompletion/CodeCompletionItem.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/CodeCompletion/CodeCompletionItem.cs
@@ -1,5 +1,7 @@
-﻿using System;
+﻿using Newtonsoft.Json;
+using System;
 using System.Collections.Generic;
+using System.Diagnostics.Contracts;
 using System.Text;
 
 namespace AnZwDev.ALTools.CodeCompletion
@@ -7,11 +9,23 @@ namespace AnZwDev.ALTools.CodeCompletion
     public class CodeCompletionItem
     {
 
+        [JsonProperty("label", NullValueHandling = NullValueHandling.Ignore)]
         public string label { get; set; }
+
+        [JsonProperty("kind")]
         public CompletionItemKind kind { get; set; }
+
+        [JsonProperty("filterText", NullValueHandling = NullValueHandling.Ignore)]
         public string filterText { get; set; }
+
+        [JsonProperty("detail", NullValueHandling = NullValueHandling.Ignore)]
         public string detail { get; set; }
+
+        [JsonProperty("tags", NullValueHandling = NullValueHandling.Ignore)]
         public List<CodeCompletionItemTag> tags { get; set; }
+
+        [JsonProperty("commitCharacters", NullValueHandling = NullValueHandling.Ignore)]
+        public string[] commitCharacters { get; set; }
 
         public CodeCompletionItem()
         { 

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/CodeCompletion/VariableDataTypesCompletionProvider.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/CodeCompletion/VariableDataTypesCompletionProvider.cs
@@ -14,6 +14,8 @@ namespace AnZwDev.ALTools.CodeCompletion
     public class VariableDataTypesCompletionProvider : CodeCompletionProvider
     {
 
+        private static string[] _commitCharacters = { ";" };
+
         public VariableDataTypesCompletionProvider(ALDevToolsServer server) : base(server, "VariableDataTypes")
         {
         }
@@ -108,6 +110,7 @@ namespace AnZwDev.ALTools.CodeCompletion
                     if ((temporaryRecordVariable) && (!varName.StartsWith("Temp", StringComparison.CurrentCultureIgnoreCase)))
                         varDataType = varDataType + " temporary";
                     var item = new CodeCompletionItem(varDataType, CompletionItemKind.Class);
+                    item.commitCharacters = _commitCharacters;
                     completionItems.Add(item);
                 }
             }

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/CodeCompletion/VariableDataTypesCompletionProvider.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/CodeCompletion/VariableDataTypesCompletionProvider.cs
@@ -103,7 +103,7 @@ namespace AnZwDev.ALTools.CodeCompletion
             {
                 var varName = ALSyntaxHelper.ObjectNameToVariableNamePart(type.Name)
                     .ToLower()
-                    .RemovePrefixSuffix(project.MandatoryPrefixes, project.MandatorySuffixes, project.MandatoryAffixes);
+                    .RemovePrefixSuffix(project.MandatoryPrefixes, project.MandatorySuffixes, project.MandatoryAffixes, project.AdditionalMandatoryAffixesPatterns);
                 if (name.Contains(varName))
                 {
                     var varDataType = type.GetALSymbolKind().ToVariableTypeName() + " " + ALSyntaxHelper.EncodeName(type.Name);

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/CodeCompletion/VariableNamesCompletionProvider.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/CodeCompletion/VariableNamesCompletionProvider.cs
@@ -181,8 +181,8 @@ namespace AnZwDev.ALTools.CodeCompletion
         {
             foreach (var type in typesCollection)
             {
-                var varName = ALSyntaxHelper.ObjectNameToVariableNamePart(type.Name)
-                    .RemovePrefixSuffix(project.MandatoryPrefixes, project.MandatorySuffixes, project.MandatoryAffixes);
+                var varName = ALSyntaxHelper.ObjectNameToVariableNamePart(
+                    type.Name.RemovePrefixSuffix(project.MandatoryPrefixes, project.MandatorySuffixes, project.MandatoryAffixes, project.AdditionalMandatoryAffixesPatterns));
 
                 var addTemporary = (asTemporaryVariable) && (!varName.StartsWith(_tempPrefix, StringComparison.CurrentCultureIgnoreCase));
 

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/CodeTransformations/ALCaptionsSyntaxRewriter.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/CodeTransformations/ALCaptionsSyntaxRewriter.cs
@@ -28,7 +28,8 @@ namespace AnZwDev.ALTools.CodeTransformations
 
         protected PropertySyntax CreateCaptionPropertyFromName(SyntaxNode node, bool locked)
         {
-            string value = node.GetNameStringValue().RemovePrefixSuffix(this.Project.MandatoryPrefixes, this.Project.MandatorySuffixes, this.Project.MandatoryAffixes);
+            string value = node.GetNameStringValue().RemovePrefixSuffix(
+                this.Project.MandatoryPrefixes, this.Project.MandatorySuffixes, this.Project.MandatoryAffixes, this.Project.AdditionalMandatoryAffixesPatterns);
 
             SyntaxTriviaList leadingTriviaList = node.CreateChildNodeIdentTrivia();
             SyntaxTriviaList trailingTriviaList = SyntaxFactory.ParseTrailingTrivia("\r\n", 0);

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/CodeTransformations/AppAreaMode.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/CodeTransformations/AppAreaMode.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace AnZwDev.ALTools.CodeTransformations
+{
+    public enum AppAreaMode
+    {
+        inheritFromMainObject = 0,
+        addToAllControls = 1
+    }
+}

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/CodeTransformations/AppAreaSyntaxRewriter.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/CodeTransformations/AppAreaSyntaxRewriter.cs
@@ -11,11 +11,11 @@ namespace AnZwDev.ALTools.CodeTransformations
     public class AppAreaSyntaxRewriter : ALSyntaxRewriter
     {
 
-        public string ApplicationAreaName { get; set; }
+        public string ApplicationAreaName { get; set; } = null;
+        public AppAreaMode ApplicationAreaMode { get; set; } = AppAreaMode.addToAllControls;
 
         public AppAreaSyntaxRewriter()
         {
-            this.ApplicationAreaName = null;
         }
 
         protected override SyntaxNode AfterVisitNode(SyntaxNode node)
@@ -35,7 +35,11 @@ namespace AnZwDev.ALTools.CodeTransformations
                 hasUsageCategory = ((!String.IsNullOrWhiteSpace(usageCategory)) && (usageCategory.ToLower() != "none"));
             }
 
-            if ((hasUsageCategory) && (!this.HasApplicationArea(node)))
+            if ((
+                    (hasUsageCategory) || 
+                    (ApplicationAreaMode == AppAreaMode.inheritFromMainObject)
+                ) && 
+                (!this.HasApplicationArea(node)))
             {
                 NoOfChanges++;
                 node = node.AddPropertyListProperties(this.CreateApplicationAreaProperty(node));
@@ -46,7 +50,7 @@ namespace AnZwDev.ALTools.CodeTransformations
 
         public override SyntaxNode VisitPageLabel(PageLabelSyntax node)
         {
-            if (this.HasApplicationArea(node))
+            if ((ApplicationAreaMode == AppAreaMode.inheritFromMainObject) || (this.HasApplicationArea(node)))
                 return base.VisitPageLabel(node);
             this.NoOfChanges++;
             return node.AddPropertyListProperties(this.CreateApplicationAreaProperty(node));
@@ -54,7 +58,7 @@ namespace AnZwDev.ALTools.CodeTransformations
 
         public override SyntaxNode VisitPageField(PageFieldSyntax node)
         {
-            if (this.HasApplicationArea(node))
+            if ((ApplicationAreaMode == AppAreaMode.inheritFromMainObject) || (this.HasApplicationArea(node)))
                 return base.VisitPageField(node);
             this.NoOfChanges++;
             return node.AddPropertyListProperties(this.CreateApplicationAreaProperty(node));
@@ -62,7 +66,7 @@ namespace AnZwDev.ALTools.CodeTransformations
 
         public override SyntaxNode VisitPageUserControl(PageUserControlSyntax node)
         {
-            if (this.HasApplicationArea(node))
+            if ((ApplicationAreaMode == AppAreaMode.inheritFromMainObject) || (this.HasApplicationArea(node)))
                 return base.VisitPageUserControl(node);
             this.NoOfChanges++;
             return node.AddPropertyListProperties(this.CreateApplicationAreaProperty(node));
@@ -70,7 +74,7 @@ namespace AnZwDev.ALTools.CodeTransformations
 
         public override SyntaxNode VisitPagePart(PagePartSyntax node)
         {
-            if (this.HasApplicationArea(node))
+            if ((ApplicationAreaMode == AppAreaMode.inheritFromMainObject) || (this.HasApplicationArea(node)))
                 return base.VisitPagePart(node);
             this.NoOfChanges++;
             return node.AddPropertyListProperties(this.CreateApplicationAreaProperty(node));
@@ -78,7 +82,7 @@ namespace AnZwDev.ALTools.CodeTransformations
 
         public override SyntaxNode VisitPageSystemPart(PageSystemPartSyntax node)
         {
-            if (this.HasApplicationArea(node))
+            if ((ApplicationAreaMode == AppAreaMode.inheritFromMainObject) || (this.HasApplicationArea(node)))
                 return base.VisitPageSystemPart(node);
             this.NoOfChanges++;
             return node.AddPropertyListProperties(this.CreateApplicationAreaProperty(node));
@@ -87,7 +91,7 @@ namespace AnZwDev.ALTools.CodeTransformations
 #if BC
         public override SyntaxNode VisitPageChartPart(PageChartPartSyntax node)
         {
-            if (this.HasApplicationArea(node))
+            if ((ApplicationAreaMode == AppAreaMode.inheritFromMainObject) || (this.HasApplicationArea(node)))
                 return base.VisitPageChartPart(node);
             this.NoOfChanges++;
             return node.AddPropertyListProperties(this.CreateApplicationAreaProperty(node));
@@ -96,7 +100,7 @@ namespace AnZwDev.ALTools.CodeTransformations
 
         public override SyntaxNode VisitPageAction(PageActionSyntax node)
         {
-            if (this.HasApplicationArea(node))
+            if ((ApplicationAreaMode == AppAreaMode.inheritFromMainObject) || (this.HasApplicationArea(node)))
                 return base.VisitPageAction(node);
             this.NoOfChanges++;
             return node.AddPropertyListProperties(this.CreateApplicationAreaProperty(node));

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/CodeTransformations/BasePageWithSourceSyntaxRewriter.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/CodeTransformations/BasePageWithSourceSyntaxRewriter.cs
@@ -138,7 +138,8 @@ namespace AnZwDev.ALTools.CodeTransformations
                 }
 
                 if ((String.IsNullOrWhiteSpace(caption)) && (fieldName != null))
-                    caption = fieldName.Replace("\"", "").RemovePrefixSuffix(this.Project.MandatoryPrefixes, this.Project.MandatorySuffixes, this.Project.MandatoryAffixes);
+                    caption = fieldName.Replace("\"", "").RemovePrefixSuffix(
+                        this.Project.MandatoryPrefixes, this.Project.MandatorySuffixes, this.Project.MandatoryAffixes, this.Project.AdditionalMandatoryAffixesPatterns);
             }
             return new TableFieldCaptionInfo(new LabelInformation("Caption", caption), description, null);
         }

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/CodeTransformations/DataClassificationSyntaxRewriter.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/CodeTransformations/DataClassificationSyntaxRewriter.cs
@@ -62,6 +62,17 @@ namespace AnZwDev.ALTools.CodeTransformations
                         return node.ReplaceNode(propertySyntax, this.CreateDataClassificationProperty(node));
                     }
                 }
+            } 
+            else
+            {
+                PropertySyntax propertySyntax = node.GetProperty("DataClassification");
+                if (propertySyntax != null)
+                {
+                    NoOfChanges++;
+                    return node.WithPropertyList(
+                        node.PropertyList.WithProperties(
+                            node.PropertyList.Properties.Remove(propertySyntax)));
+                }
             }
             return base.VisitField(node);
         }

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/CodeTransformations/DirectiveTriviaMergedList.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/CodeTransformations/DirectiveTriviaMergedList.cs
@@ -1,0 +1,75 @@
+﻿using AnZwDev.ALTools.ALSymbols.Internal;
+using AnZwDev.ALTools.Extensions;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Syntax;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace AnZwDev.ALTools.CodeTransformations
+{
+    public class DirectiveTriviaMergedList
+    {
+
+        public List<SyntaxTrivia> List { get; }
+        private bool _addNewLine = false;
+
+        public DirectiveTriviaMergedList()
+        {
+            List = new List<SyntaxTrivia>();
+        }
+
+        public void AddRange(IEnumerable<SyntaxTrivia> collection)
+        {
+            foreach (var trivia in collection)
+            {
+                var kind = trivia.Kind.ConvertToLocalType();
+                if (kind == ConvertedSyntaxKind.EndOfLineTrivia)
+                {
+                    if (_addNewLine)
+                        List.Add(trivia);
+                    _addNewLine = false;
+                } 
+                else if (CanMerge(kind))
+                {
+                    List.Add(trivia);
+                    _addNewLine = true;
+                }
+            }
+        }
+
+        private bool CanMerge(ConvertedSyntaxKind kind)
+        {
+            switch (kind)
+            {
+                case ConvertedSyntaxKind.BadDirectiveTrivia:
+                case ConvertedSyntaxKind.BadPragmaDirectiveTrivia:
+                case ConvertedSyntaxKind.DefineDirectiveTrivia:
+                case ConvertedSyntaxKind.ElifDirectiveTrivia:
+                case ConvertedSyntaxKind.ElseDirectiveTrivia:
+                case ConvertedSyntaxKind.IfDirectiveTrivia:
+                case ConvertedSyntaxKind.PreprocessingMessageTrivia:
+                case ConvertedSyntaxKind.RegionDirectiveTrivia:
+                case ConvertedSyntaxKind.UndefDirectiveTrivia:
+                case ConvertedSyntaxKind.PragmaImplicitWithDirectiveTrivia:
+                case ConvertedSyntaxKind.PragmaWarningDirectiveTrivia:
+                    return true;
+                case ConvertedSyntaxKind.EndRegionDirectiveTrivia:
+                    return !RemoveLastRegion();
+            }
+            return false;
+        }
+
+        private bool RemoveLastRegion()
+        {
+            for (int i=List.Count - 1; i>=0; i++)
+                if (List[i].Kind.ConvertToLocalType() == ConvertedSyntaxKind.RegionDirectiveTrivia)
+                {
+                    List.RemoveAt(i);
+                    return true;
+                }
+            return false;
+        }
+
+    }
+
+}

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/CodeTransformations/MakeFlowFieldsReadOnlySyntaxRewriter.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/CodeTransformations/MakeFlowFieldsReadOnlySyntaxRewriter.cs
@@ -1,0 +1,50 @@
+﻿using AnZwDev.ALTools.Extensions;
+using Microsoft.Dynamics.Nav.CodeAnalysis;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Syntax;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace AnZwDev.ALTools.CodeTransformations
+{
+    public class MakeFlowFieldsReadOnlySyntaxRewriter : ALSyntaxRewriter
+    {
+
+        public MakeFlowFieldsReadOnlySyntaxRewriter()
+        {
+        }
+
+        public override SyntaxNode VisitField(FieldSyntax node)
+        {
+            PropertyValueSyntax fieldClass = node.GetPropertyValue("FieldClass");
+            if ((fieldClass != null) && (fieldClass.ToString().Equals("FlowField", StringComparison.CurrentCultureIgnoreCase)))
+            {
+                PropertySyntax propertySyntax = node.GetProperty("Editable");
+                if (propertySyntax == null)
+                {
+                    NoOfChanges++;
+                    node = node.AddPropertyListProperties(this.CreateReadOnlyProperty(node));
+                }
+            }
+            return base.VisitField(node);
+        }
+
+        protected PropertySyntax CreateReadOnlyProperty(SyntaxNode node)
+        {
+            SyntaxTriviaList leadingTriviaList = node.CreateChildNodeIdentTrivia();
+            SyntaxTriviaList trailingTriviaList = SyntaxFactory.ParseTrailingTrivia("\r\n", 0);
+
+            return SyntaxFactory.Property(
+                SyntaxFactory.PropertyName(SyntaxFactory.Identifier("Editable"))
+                    .WithTrailingTrivia(SyntaxFactory.ParseTrailingTrivia(" ")),
+                SyntaxFactory.BooleanPropertyValue(SyntaxFactory.BooleanLiteralValue(
+                    SyntaxFactory.Token(SyntaxKind.FalseKeyword)))
+                    .WithLeadingTrivia(SyntaxFactory.ParseLeadingTrivia(" ")))
+                .WithLeadingTrivia(leadingTriviaList)
+                .WithTrailingTrivia(trailingTriviaList);
+        }
+
+
+
+    }
+}

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/CodeTransformations/PageControlCaptionSyntaxRewriter.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/CodeTransformations/PageControlCaptionSyntaxRewriter.cs
@@ -60,7 +60,8 @@ namespace AnZwDev.ALTools.CodeTransformations
                 PropertySyntax propertySyntax = node.GetProperty("Caption");
                 if ((propertySyntax == null) || (String.IsNullOrWhiteSpace(propertySyntax.Value.ToString())))
                 {
-                    string caption = node.GetNameStringValue().RemovePrefixSuffix(this.Project.MandatoryPrefixes, this.Project.MandatorySuffixes, this.Project.MandatoryAffixes);
+                    string caption = node.GetNameStringValue().RemovePrefixSuffix(
+                        this.Project.MandatoryPrefixes, this.Project.MandatorySuffixes, this.Project.MandatoryAffixes, this.Project.AdditionalMandatoryAffixesPatterns);
                     if (!String.IsNullOrWhiteSpace(caption))
                     {
                         PropertySyntax newPropertySyntax = this.CreateCaptionProperty(node, caption, null);
@@ -82,7 +83,8 @@ namespace AnZwDev.ALTools.CodeTransformations
                 PropertySyntax propertySyntax = node.GetProperty("Caption");
                 if ((propertySyntax == null) || (String.IsNullOrWhiteSpace(propertySyntax.Value.ToString())))
                 {
-                    string caption = node.GetNameStringValue().RemovePrefixSuffix(this.Project.MandatoryPrefixes, this.Project.MandatorySuffixes, this.Project.MandatoryAffixes);
+                    string caption = node.GetNameStringValue().RemovePrefixSuffix(
+                        this.Project.MandatoryPrefixes, this.Project.MandatorySuffixes, this.Project.MandatoryAffixes, this.Project.AdditionalMandatoryAffixesPatterns);
                     if (!String.IsNullOrWhiteSpace(caption))
                     {
                         PropertySyntax newPropertySyntax = this.CreateCaptionProperty(node, caption, null);
@@ -104,7 +106,8 @@ namespace AnZwDev.ALTools.CodeTransformations
                 PropertySyntax propertySyntax = node.GetProperty("Caption");
                 if ((propertySyntax == null) || (String.IsNullOrWhiteSpace(propertySyntax.Value.ToString())))
                 {
-                    string caption = node.GetNameStringValue().RemovePrefixSuffix(this.Project.MandatoryPrefixes, this.Project.MandatorySuffixes, this.Project.MandatoryAffixes);
+                    string caption = node.GetNameStringValue().RemovePrefixSuffix(
+                        this.Project.MandatoryPrefixes, this.Project.MandatorySuffixes, this.Project.MandatoryAffixes, this.Project.AdditionalMandatoryAffixesPatterns);
                     if (!String.IsNullOrWhiteSpace(caption))
                     {
                         PropertySyntax newPropertySyntax = this.CreateCaptionProperty(node, caption, null);
@@ -126,7 +129,8 @@ namespace AnZwDev.ALTools.CodeTransformations
                 PropertySyntax propertySyntax = node.GetProperty("Caption");
                 if ((propertySyntax == null) || (String.IsNullOrWhiteSpace(propertySyntax.Value.ToString())))
                 {
-                    string caption = node.GetNameStringValue().RemovePrefixSuffix(this.Project.MandatoryPrefixes, this.Project.MandatorySuffixes, this.Project.MandatoryAffixes);
+                    string caption = node.GetNameStringValue().RemovePrefixSuffix(
+                        this.Project.MandatoryPrefixes, this.Project.MandatorySuffixes, this.Project.MandatoryAffixes, this.Project.AdditionalMandatoryAffixesPatterns);
                     if (!String.IsNullOrWhiteSpace(caption))
                     {
                         PropertySyntax newPropertySyntax = this.CreateCaptionProperty(node, caption, null);
@@ -150,7 +154,8 @@ namespace AnZwDev.ALTools.CodeTransformations
                     string caption = ALSyntaxHelper.DecodeName(node.PartName.ToString());
                     if (String.IsNullOrWhiteSpace(caption))
                         caption = node.GetNameStringValue();
-                    caption = caption.RemovePrefixSuffix(this.Project.MandatoryPrefixes, this.Project.MandatorySuffixes, this.Project.MandatoryAffixes);
+                    caption = caption.RemovePrefixSuffix(
+                        this.Project.MandatoryPrefixes, this.Project.MandatorySuffixes, this.Project.MandatoryAffixes, this.Project.AdditionalMandatoryAffixesPatterns);
                     if (!String.IsNullOrWhiteSpace(caption))
                     {
                         PropertySyntax newPropertySyntax = this.CreateCaptionProperty(node, caption, null);

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/CodeTransformations/RemoveEmptyTriggersSyntaxRewriter.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/CodeTransformations/RemoveEmptyTriggersSyntaxRewriter.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Xml.Linq;
 
 namespace AnZwDev.ALTools.CodeTransformations
 {
@@ -19,41 +20,456 @@ namespace AnZwDev.ALTools.CodeTransformations
         {
         }
 
-        public override SyntaxNode VisitTriggerDeclaration(TriggerDeclarationSyntax node)
+        #region Visit objects declaration members
+
+        public override SyntaxNode VisitTable(TableSyntax node)
         {
-            if (RemoveTriggers && IsEmptyMethod(node))
+            (var newMembers, var remainingTrivia, var updated) = ProcessMembersList(node.Members);
+            if (updated)
             {
-                NoOfChanges++;
-
-                var mergedList = new DirectiveTriviaMergedList();
-                mergedList.AddRange(node.GetLeadingTrivia());
-                mergedList.AddRange(node.GetTrailingTrivia());
-                if (mergedList.List.Count > 0)
-                    return SyntaxFactory.EmptyStatement().WithLeadingTrivia(mergedList.List);
-
-                return null;
+                node = node.WithMembers(newMembers);
+                if ((remainingTrivia != null) && (remainingTrivia.List.Count > 0) && (!node.CloseBraceToken.IsEmpty()))
+                {
+                    remainingTrivia.AddAllExceptClosingRegions(node.CloseBraceToken.LeadingTrivia);
+                    node = node.WithCloseBraceToken(
+                        node.CloseBraceToken.WithLeadingTrivia(remainingTrivia.List));
+                }
             }
-            return base.VisitTriggerDeclaration(node);
+            return base.VisitTable(node);
         }
 
-        public override SyntaxNode VisitMethodDeclaration(MethodDeclarationSyntax node)
+        public override SyntaxNode VisitTableExtension(TableExtensionSyntax node)
         {
-            if (RemoveSubscribers && IsEmptyMethod(node) && IsEventSubscriber(node))
+            (var newMembers, var remainingTrivia, var updated) = ProcessMembersList(node.Members);
+            if (updated)
             {
-                NoOfChanges++;
-                return null;
+                node = node.WithMembers(newMembers);
+                if ((remainingTrivia != null) && (remainingTrivia.List.Count > 0) && (!node.CloseBraceToken.IsEmpty()))
+                {
+                    remainingTrivia.AddAllExceptClosingRegions(node.CloseBraceToken.LeadingTrivia);
+                    node = node.WithCloseBraceToken(
+                        node.CloseBraceToken.WithLeadingTrivia(remainingTrivia.List));
+                }
             }
-            return base.VisitMethodDeclaration(node);
+            return base.VisitTableExtension(node);
+        }
+
+        public override SyntaxNode VisitPage(PageSyntax node)
+        {
+            (var newMembers, var remainingTrivia, var updated) = ProcessMembersList(node.Members);
+            if (updated)
+            {
+                node = node.WithMembers(newMembers);
+                if ((remainingTrivia != null) && (remainingTrivia.List.Count > 0) && (!node.CloseBraceToken.IsEmpty()))
+                {
+                    remainingTrivia.AddAllExceptClosingRegions(node.CloseBraceToken.LeadingTrivia);
+                    node = node.WithCloseBraceToken(
+                        node.CloseBraceToken.WithLeadingTrivia(remainingTrivia.List));
+                }
+            }
+            return base.VisitPage(node);
+        }
+
+        public override SyntaxNode VisitPageExtension(PageExtensionSyntax node)
+        {
+            (var newMembers, var remainingTrivia, var updated) = ProcessMembersList(node.Members);
+            if (updated)
+            {
+                node = node.WithMembers(newMembers);
+                if ((remainingTrivia != null) && (remainingTrivia.List.Count > 0) && (!node.CloseBraceToken.IsEmpty()))
+                {
+                    remainingTrivia.AddAllExceptClosingRegions(node.CloseBraceToken.LeadingTrivia);
+                    node = node.WithCloseBraceToken(
+                        node.CloseBraceToken.WithLeadingTrivia(remainingTrivia.List));
+                }
+            }
+            return base.VisitPageExtension(node);
+        }
+
+        public override SyntaxNode VisitReport(ReportSyntax node)
+        {
+            (var newMembers, var remainingTrivia, var updated) = ProcessMembersList(node.Members);
+            if (updated)
+            {
+                node = node.WithMembers(newMembers);
+                if ((remainingTrivia != null) && (remainingTrivia.List.Count > 0) && (!node.CloseBraceToken.IsEmpty()))
+                {
+                    remainingTrivia.AddAllExceptClosingRegions(node.CloseBraceToken.LeadingTrivia);
+                    node = node.WithCloseBraceToken(
+                        node.CloseBraceToken.WithLeadingTrivia(remainingTrivia.List));
+                }
+            }
+            return base.VisitReport(node);
+        }
+
+#if BC
+        public override SyntaxNode VisitReportExtension(ReportExtensionSyntax node)
+        {
+            (var newMembers, var remainingTrivia, var updated) = ProcessMembersList(node.Members);
+            if (updated)
+            {
+                node = node.WithMembers(newMembers);
+                if ((remainingTrivia != null) && (remainingTrivia.List.Count > 0) && (!node.CloseBraceToken.IsEmpty()))
+                {
+                    remainingTrivia.AddAllExceptClosingRegions(node.CloseBraceToken.LeadingTrivia);
+                    node = node.WithCloseBraceToken(
+                        node.CloseBraceToken.WithLeadingTrivia(remainingTrivia.List));
+                }
+            }
+            return base.VisitReportExtension(node);
+        }
+#endif
+
+        public override SyntaxNode VisitQuery(QuerySyntax node)
+        {
+            (var newMembers, var remainingTrivia, var updated) = ProcessMembersList(node.Members);
+            if (updated)
+            {
+                node = node.WithMembers(newMembers);
+                if ((remainingTrivia != null) && (remainingTrivia.List.Count > 0) && (!node.CloseBraceToken.IsEmpty()))
+                {
+                    remainingTrivia.AddAllExceptClosingRegions(node.CloseBraceToken.LeadingTrivia);
+                    node = node.WithCloseBraceToken(
+                        node.CloseBraceToken.WithLeadingTrivia(remainingTrivia.List));
+                }
+            }
+            return base.VisitQuery(node);
+        }
+
+        public override SyntaxNode VisitCodeunit(CodeunitSyntax node)
+        {
+            (var newMembers, var remainingTrivia, var updated) = ProcessMembersList(node.Members);
+            if (updated)
+            {
+                node = node.WithMembers(newMembers);
+                if ((remainingTrivia != null) && (remainingTrivia.List.Count > 0) && (!node.CloseBraceToken.IsEmpty()))
+                {
+                    remainingTrivia.AddAllExceptClosingRegions(node.CloseBraceToken.LeadingTrivia);
+                    node = node.WithCloseBraceToken(
+                        node.CloseBraceToken.WithLeadingTrivia(remainingTrivia.List));
+                }
+            }
+            return base.VisitCodeunit(node);
+        }
+
+        public override SyntaxNode VisitXmlPort(XmlPortSyntax node)
+        {
+            (var newMembers, var remainingTrivia, var updated) = ProcessMembersList(node.Members);
+            if (updated)
+            {
+                node = node.WithMembers(newMembers);
+                if ((remainingTrivia != null) && (remainingTrivia.List.Count > 0) && (!node.CloseBraceToken.IsEmpty()))
+                {
+                    remainingTrivia.AddAllExceptClosingRegions(node.CloseBraceToken.LeadingTrivia);
+                    node = node.WithCloseBraceToken(
+                        node.CloseBraceToken.WithLeadingTrivia(remainingTrivia.List));
+                }
+            }
+            return base.VisitXmlPort(node);
+        }
+
+        #endregion
+
+        #region Visit nodes with triggers
+
+        #region Tables and Table Extensions
+
+        public override SyntaxNode VisitFieldModification(FieldModificationSyntax node)
+        {
+            (var newMembers, var remainingTrivia, var updated) = ProcessMembersList(node.Triggers);
+            if (updated)
+            {
+                node = node.WithTriggers(newMembers);
+                if ((remainingTrivia != null) && (remainingTrivia.List.Count > 0) && (!node.CloseBraceToken.IsEmpty()))
+                {
+                    remainingTrivia.AddAllExceptClosingRegions(node.CloseBraceToken.LeadingTrivia);
+                    node = node.WithCloseBraceToken(
+                        node.CloseBraceToken.WithLeadingTrivia(remainingTrivia.List));
+                }
+            }
+            return base.VisitFieldModification(node);
+        }
+
+        public override SyntaxNode VisitField(FieldSyntax node)
+        {
+            (var newMembers, var remainingTrivia, var updated) = ProcessMembersList(node.Triggers);
+            if (updated)
+            {
+                node = node.WithTriggers(newMembers);
+                if ((remainingTrivia != null) && (remainingTrivia.List.Count > 0) && (!node.CloseBraceToken.IsEmpty()))
+                {
+                    remainingTrivia.AddAllExceptClosingRegions(node.CloseBraceToken.LeadingTrivia);
+                    node = node.WithCloseBraceToken(
+                        node.CloseBraceToken.WithLeadingTrivia(remainingTrivia.List));
+                }
+            }
+            return base.VisitField(node);
+        }
+
+        #endregion
+
+        #region Pages and Page Extensions
+
+        public override SyntaxNode VisitActionModifyChange(ActionModifyChangeSyntax node)
+        {
+            (var newMembers, var remainingTrivia, var updated) = ProcessMembersList(node.Triggers);
+            if (updated)
+            {
+                node = node.WithTriggers(newMembers);
+                if ((remainingTrivia != null) && (remainingTrivia.List.Count > 0) && (!node.CloseBraceToken.IsEmpty()))
+                {
+                    remainingTrivia.AddAllExceptClosingRegions(node.CloseBraceToken.LeadingTrivia);
+                    node = node.WithCloseBraceToken(
+                        node.CloseBraceToken.WithLeadingTrivia(remainingTrivia.List));
+                }
+            }
+            return base.VisitActionModifyChange(node);
+        }
+
+        public override SyntaxNode VisitControlModifyChange(ControlModifyChangeSyntax node)
+        {
+            (var newMembers, var remainingTrivia, var updated) = ProcessMembersList(node.Triggers);
+            if (updated)
+            {
+                node = node.WithTriggers(newMembers);
+                if ((remainingTrivia != null) && (remainingTrivia.List.Count > 0) && (!node.CloseBraceToken.IsEmpty()))
+                {
+                    remainingTrivia.AddAllExceptClosingRegions(node.CloseBraceToken.LeadingTrivia);
+                    node = node.WithCloseBraceToken(
+                        node.CloseBraceToken.WithLeadingTrivia(remainingTrivia.List));
+                }
+            }
+            return base.VisitControlModifyChange(node);
+        }
+
+        public override SyntaxNode VisitPageField(PageFieldSyntax node)
+        {
+            (var newMembers, var remainingTrivia, var updated) = ProcessMembersList(node.Triggers);
+            if (updated)
+            {
+                node = node.WithTriggers(newMembers);
+                if ((remainingTrivia != null) && (remainingTrivia.List.Count > 0) && (!node.CloseBraceToken.IsEmpty()))
+                {
+                    remainingTrivia.AddAllExceptClosingRegions(node.CloseBraceToken.LeadingTrivia);
+                    node = node.WithCloseBraceToken(
+                        node.CloseBraceToken.WithLeadingTrivia(remainingTrivia.List));
+                }
+            }
+            return base.VisitPageField(node);
+        }
+
+        public override SyntaxNode VisitPageAction(PageActionSyntax node)
+        {
+            (var newMembers, var remainingTrivia, var updated) = ProcessMembersList(node.Triggers);
+            if (updated)
+            {
+                node = node.WithTriggers(newMembers);
+                if ((remainingTrivia != null) && (remainingTrivia.List.Count > 0) && (!node.CloseBraceToken.IsEmpty()))
+                {
+                    remainingTrivia.AddAllExceptClosingRegions(node.CloseBraceToken.LeadingTrivia);
+                    node = node.WithCloseBraceToken(
+                        node.CloseBraceToken.WithLeadingTrivia(remainingTrivia.List));
+                }
+            }
+            return base.VisitPageAction(node);
+        }
+
+        public override SyntaxNode VisitPageUserControl(PageUserControlSyntax node)
+        {
+            (var newMembers, var remainingTrivia, var updated) = ProcessMembersList(node.Triggers);
+            if (updated)
+            {
+                node = node.WithTriggers(newMembers);
+                if ((remainingTrivia != null) && (remainingTrivia.List.Count > 0) && (!node.CloseBraceToken.IsEmpty()))
+                {
+                    remainingTrivia.AddAllExceptClosingRegions(node.CloseBraceToken.LeadingTrivia);
+                    node = node.WithCloseBraceToken(
+                        node.CloseBraceToken.WithLeadingTrivia(remainingTrivia.List));
+                }
+            }
+            return base.VisitPageUserControl(node);
+        }
+
+        #endregion
+
+        #region XmlPorts
+
+        public override SyntaxNode VisitXmlPortFieldAttribute(XmlPortFieldAttributeSyntax node)
+        {
+            (var newMembers, var remainingTrivia, var updated) = ProcessMembersList(node.Triggers);
+            if (updated)
+            {
+                node = node.WithTriggers(newMembers);
+                if ((remainingTrivia != null) && (remainingTrivia.List.Count > 0) && (!node.CloseBraceToken.IsEmpty()))
+                {
+                    remainingTrivia.AddAllExceptClosingRegions(node.CloseBraceToken.LeadingTrivia);
+                    node = node.WithCloseBraceToken(
+                        node.CloseBraceToken.WithLeadingTrivia(remainingTrivia.List));
+                }
+            }
+            return base.VisitXmlPortFieldAttribute(node);
+        }
+
+        public override SyntaxNode VisitXmlPortFieldElement(XmlPortFieldElementSyntax node)
+        {
+            (var newMembers, var remainingTrivia, var updated) = ProcessMembersList(node.Triggers);
+            if (updated)
+            {
+                node = node.WithTriggers(newMembers);
+                if ((remainingTrivia != null) && (remainingTrivia.List.Count > 0) && (!node.CloseBraceToken.IsEmpty()))
+                {
+                    remainingTrivia.AddAllExceptClosingRegions(node.CloseBraceToken.LeadingTrivia);
+                    node = node.WithCloseBraceToken(
+                        node.CloseBraceToken.WithLeadingTrivia(remainingTrivia.List));
+                }
+            }
+            return base.VisitXmlPortFieldElement(node);
+        }
+
+        public override SyntaxNode VisitXmlPortTableElement(XmlPortTableElementSyntax node)
+        {
+            (var newMembers, var remainingTrivia, var updated) = ProcessMembersList(node.Triggers);
+            if (updated)
+            {
+                node = node.WithTriggers(newMembers);
+                if ((remainingTrivia != null) && (remainingTrivia.List.Count > 0) && (!node.CloseBraceToken.IsEmpty()))
+                {
+                    remainingTrivia.AddAllExceptClosingRegions(node.CloseBraceToken.LeadingTrivia);
+                    node = node.WithCloseBraceToken(
+                        node.CloseBraceToken.WithLeadingTrivia(remainingTrivia.List));
+                }
+            }
+            return base.VisitXmlPortTableElement(node);
+        }
+
+        public override SyntaxNode VisitXmlPortTextAttribute(XmlPortTextAttributeSyntax node)
+        {
+            (var newMembers, var remainingTrivia, var updated) = ProcessMembersList(node.Triggers);
+            if (updated)
+            {
+                node = node.WithTriggers(newMembers);
+                if ((remainingTrivia != null) && (remainingTrivia.List.Count > 0) && (!node.CloseBraceToken.IsEmpty()))
+                {
+                    remainingTrivia.AddAllExceptClosingRegions(node.CloseBraceToken.LeadingTrivia);
+                    node = node.WithCloseBraceToken(
+                        node.CloseBraceToken.WithLeadingTrivia(remainingTrivia.List));
+                }
+            }
+            return base.VisitXmlPortTextAttribute(node);
+        }
+
+        public override SyntaxNode VisitXmlPortTextElement(XmlPortTextElementSyntax node)
+        {
+            (var newMembers, var remainingTrivia, var updated) = ProcessMembersList(node.Triggers);
+            if (updated)
+            {
+                node = node.WithTriggers(newMembers);
+                if ((remainingTrivia != null) && (remainingTrivia.List.Count > 0) && (!node.CloseBraceToken.IsEmpty()))
+                {
+                    remainingTrivia.AddAllExceptClosingRegions(node.CloseBraceToken.LeadingTrivia);
+                    node = node.WithCloseBraceToken(
+                        node.CloseBraceToken.WithLeadingTrivia(remainingTrivia.List));
+                }
+            }
+            return base.VisitXmlPortTextElement(node);
+        }
+
+        #endregion
+
+        #region Reports and Report Extensions
+
+        public override SyntaxNode VisitReportDataItem(ReportDataItemSyntax node)
+        {
+            (var newMembers, var remainingTrivia, var updated) = ProcessMembersList(node.Triggers);
+            if (updated)
+            {
+                node = node.WithTriggers(newMembers);
+                if ((remainingTrivia != null) && (remainingTrivia.List.Count > 0) && (!node.CloseBraceToken.IsEmpty()))
+                {
+                    remainingTrivia.AddAllExceptClosingRegions(node.CloseBraceToken.LeadingTrivia);
+                    node = node.WithCloseBraceToken(
+                        node.CloseBraceToken.WithLeadingTrivia(remainingTrivia.List));
+                }
+            }
+            return base.VisitReportDataItem(node);
+        }
+
+#if BC
+        public override SyntaxNode VisitReportExtensionDataSetModify(ReportExtensionDataSetModifySyntax node)
+        {
+            (var newMembers, var remainingTrivia, var updated) = ProcessMembersList(node.Triggers);
+            if (updated)
+            {
+                node = node.WithTriggers(newMembers);
+                if ((remainingTrivia != null) && (remainingTrivia.List.Count > 0) && (!node.CloseBraceToken.IsEmpty()))
+                {
+                    remainingTrivia.AddAllExceptClosingRegions(node.CloseBraceToken.LeadingTrivia);
+                    node = node.WithCloseBraceToken(
+                        node.CloseBraceToken.WithLeadingTrivia(remainingTrivia.List));
+                }
+            }
+            return base.VisitReportExtensionDataSetModify(node);
+        }
+#endif
+
+        #endregion
+
+        #endregion
+
+        private (SyntaxList<T>, DirectiveTriviaMergedList remainingTrivia, bool) ProcessMembersList<T>(SyntaxList<T> sourceNodesCollection) where T : MemberSyntax
+        {
+            bool removed = false;
+            List<T> newList = new List<T>();
+            var mergedTrivia = new DirectiveTriviaMergedList();
+
+            foreach (var sourceNode in sourceNodesCollection)
+            {
+                if (CanRemoveMember(sourceNode))
+                {
+                    removed = true;
+                    CollectRemovedNodeTrivia(sourceNode, mergedTrivia);
+                }
+                else if (mergedTrivia.List.Count > 0)
+                {
+                    mergedTrivia.AddAllExceptClosingRegions(sourceNode.GetLeadingTrivia());
+                    newList.Add(sourceNode.WithLeadingTrivia(mergedTrivia.List));
+                    mergedTrivia.Clear();
+                }
+                else
+                    newList.Add(sourceNode);
+            }
+
+            if (removed)
+                return (SyntaxFactory.List(newList), mergedTrivia, true);
+            return (sourceNodesCollection, null, false);
+        }
+
+        private bool CanRemoveMember(MemberSyntax member)
+        {
+            switch (member)
+            {
+                case TriggerDeclarationSyntax triggerSyntax:
+                    return (RemoveTriggers && IsEmptyMethod(triggerSyntax));
+                case MethodDeclarationSyntax methodSyntax:
+                    return (RemoveSubscribers && IsEmptyMethod(methodSyntax) && IsEventSubscriber(methodSyntax));
+            }
+            return false;
+        }
+
+        private void CollectRemovedNodeTrivia(SyntaxNode node, DirectiveTriviaMergedList mergedList)
+        {
+            mergedList.AddRange(node.GetLeadingTrivia());
+            mergedList.AddRange(node.GetTrailingTrivia());
         }
 
         private bool IsEmptyMethod(MethodOrTriggerDeclarationSyntax syntax)
         {
             bool hasTrivia = IgnoreComments ? BodyHasDirectives(syntax) : BodyHasNonEmptyTrivia(syntax);
             bool hasStatements = (syntax.Body?.Statements != null) && (syntax.Body.Statements.Count > 0);
-            bool hasDirectivesOutside = syntax.GetLeadingTrivia().ContainsDirectives() || syntax.GetTrailingTrivia().ContainsDirectives();
+            //bool hasDirectivesOutside = syntax.GetLeadingTrivia().ContainsDirectives() || syntax.GetTrailingTrivia().ContainsDirectives();
 
             return
-                (!hasTrivia) && (!hasStatements) && (!hasDirectivesOutside);
+                (!hasTrivia) && (!hasStatements);// && (!hasDirectivesOutside);
         }
 
         private bool BodyHasNonEmptyTrivia(MethodOrTriggerDeclarationSyntax syntax)
@@ -76,5 +492,6 @@ namespace AnZwDev.ALTools.CodeTransformations
                 (syntax.Attributes != null) &&
                 (syntax.Attributes.Where(p => (p.Name != null) && (p.Name.ToString().Equals("EventSubscriber", StringComparison.CurrentCultureIgnoreCase))).Any());
         }
+
     }
 }

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/CodeTransformations/RemoveEmptyTriggersSyntaxRewriter.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/CodeTransformations/RemoveEmptyTriggersSyntaxRewriter.cs
@@ -24,6 +24,13 @@ namespace AnZwDev.ALTools.CodeTransformations
             if (RemoveTriggers && IsEmptyMethod(node))
             {
                 NoOfChanges++;
+
+                var mergedList = new DirectiveTriviaMergedList();
+                mergedList.AddRange(node.GetLeadingTrivia());
+                mergedList.AddRange(node.GetTrailingTrivia());
+                if (mergedList.List.Count > 0)
+                    return SyntaxFactory.EmptyStatement().WithLeadingTrivia(mergedList.List);
+
                 return null;
             }
             return base.VisitTriggerDeclaration(node);
@@ -43,9 +50,10 @@ namespace AnZwDev.ALTools.CodeTransformations
         {
             bool hasTrivia = IgnoreComments ? BodyHasDirectives(syntax) : BodyHasNonEmptyTrivia(syntax);
             bool hasStatements = (syntax.Body?.Statements != null) && (syntax.Body.Statements.Count > 0);
+            bool hasDirectivesOutside = syntax.GetLeadingTrivia().ContainsDirectives() || syntax.GetTrailingTrivia().ContainsDirectives();
 
             return
-                (!hasTrivia) && (!hasStatements);
+                (!hasTrivia) && (!hasStatements) && (!hasDirectivesOutside);
         }
 
         private bool BodyHasNonEmptyTrivia(MethodOrTriggerDeclarationSyntax syntax)

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/CodeTransformations/RemoveRedundandAppAreasSyntaxRewriter.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/CodeTransformations/RemoveRedundandAppAreasSyntaxRewriter.cs
@@ -1,0 +1,216 @@
+﻿using AnZwDev.ALTools.ALSymbols;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Syntax;
+using Microsoft.Dynamics.Nav.CodeAnalysis;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using AnZwDev.ALTools.Extensions;
+using System.Linq;
+using System.Xml.Linq;
+using AnZwDev.ALTools.Workspace;
+
+namespace AnZwDev.ALTools.CodeTransformations
+{
+    public class RemoveRedundandAppAreasSyntaxRewriter : ALSyntaxRewriter
+    {
+
+        private enum PageMembersAppAreaState
+        {
+            NotChecked = 0,
+            Equal = 1,
+            Different = 2
+        }
+
+        private string _pageAppArea = null;
+        private string _pageMembersAppArea = null;
+        private PageMembersAppAreaState _pageMembersAppAreaState = PageMembersAppAreaState.NotChecked;
+
+        public RemoveRedundandAppAreasSyntaxRewriter()
+        {
+        }
+
+        protected override SyntaxNode AfterVisitNode(SyntaxNode node)
+        {
+            if (this.NoOfChanges == 0)
+                return null;
+            return base.AfterVisitNode(node);
+        }
+
+        public override SyntaxNode VisitPage(PageSyntax node)
+        {
+            _pageAppArea = GetApplicationAreaValue(node);
+            _pageMembersAppArea = null;
+            _pageMembersAppAreaState = PageMembersAppAreaState.NotChecked;
+
+            var newNode = base.VisitPage(node);
+
+            node = newNode as PageSyntax;
+            if ((node != null) && (String.IsNullOrWhiteSpace(_pageAppArea)) && (!String.IsNullOrWhiteSpace(_pageMembersAppArea)) && (_pageMembersAppAreaState == PageMembersAppAreaState.Equal))
+            {
+                NoOfChanges++;
+                node = node.AddPropertyListProperties(this.CreateApplicationAreaProperty(node, _pageMembersAppArea));
+                _pageAppArea = _pageMembersAppArea;
+
+                //run processing again to remove redundant application areas
+                return base.VisitPage(node);
+            }
+
+            return newNode;
+        }
+
+        public override SyntaxNode VisitPageLabel(PageLabelSyntax node)
+        {
+            (var propertyList, var propertyListUpdated) = CheckAndRemovePageMemberAppArea(node, node.PropertyList);
+            if (propertyListUpdated)
+                node = node.WithPropertyList(propertyList);
+            return base.VisitPageLabel(node);
+        }
+
+        public override SyntaxNode VisitPageField(PageFieldSyntax node)
+        {
+            (var propertyList, var propertyListUpdated) = CheckAndRemovePageMemberAppArea(node, node.PropertyList);
+            if (propertyListUpdated)
+                node = node.WithPropertyList(propertyList);
+            return base.VisitPageField(node);
+        }
+
+        public override SyntaxNode VisitPageUserControl(PageUserControlSyntax node)
+        {
+            (var propertyList, var propertyListUpdated) = CheckAndRemovePageMemberAppArea(node, node.PropertyList);
+            if (propertyListUpdated)
+                node = node.WithPropertyList(propertyList);
+            return base.VisitPageUserControl(node);
+        }
+
+        public override SyntaxNode VisitPagePart(PagePartSyntax node)
+        {
+            (var propertyList, var propertyListUpdated) = CheckAndRemovePageMemberAppArea(node, node.PropertyList);
+            if (propertyListUpdated)
+                node = node.WithPropertyList(propertyList);
+            return base.VisitPagePart(node);
+        }
+
+        public override SyntaxNode VisitPageSystemPart(PageSystemPartSyntax node)
+        {
+            (var propertyList, var propertyListUpdated) = CheckAndRemovePageMemberAppArea(node, node.PropertyList);
+            if (propertyListUpdated)
+                node = node.WithPropertyList(propertyList);
+            return base.VisitPageSystemPart(node);
+        }
+
+#if BC
+        public override SyntaxNode VisitPageChartPart(PageChartPartSyntax node)
+        {
+            (var propertyList, var propertyListUpdated) = CheckAndRemovePageMemberAppArea(node, node.PropertyList);
+            if (propertyListUpdated)
+                node = node.WithPropertyList(propertyList);
+            return base.VisitPageChartPart(node);
+        }
+#endif
+
+        public override SyntaxNode VisitPageAction(PageActionSyntax node)
+        {
+            (var propertyList, var propertyListUpdated) = CheckAndRemovePageMemberAppArea(node, node.PropertyList);
+            if (propertyListUpdated)
+                node = node.WithPropertyList(propertyList);
+            return base.VisitPageAction(node);
+        }
+
+        private (PropertyListSyntax, bool) CheckAndRemovePageMemberAppArea(SyntaxNode node, PropertyListSyntax propertyList)
+        {
+            PropertySyntax appAreaProperty = node.GetProperty("ApplicationArea");
+            string memberAppArea = ALSyntaxHelper.DecodeName(appAreaProperty?.Value?.ToString());
+
+            CheckIfMemberAppAreasAreTheSame(memberAppArea);
+
+            if (ShouldRemoveAppArea(memberAppArea))
+                return (RemoveProperty(propertyList, appAreaProperty), true);
+
+            return (propertyList, false);
+        }
+
+        private bool ShouldRemoveAppArea(string memberAppArea)
+        {
+            return
+                (!String.IsNullOrWhiteSpace(_pageAppArea)) &&
+                (!String.IsNullOrWhiteSpace(memberAppArea)) &&
+                (memberAppArea.Equals(_pageAppArea, StringComparison.CurrentCultureIgnoreCase));
+        }
+
+        private PropertyListSyntax RemoveProperty(PropertyListSyntax propertyList, PropertySyntax property)
+        {
+            NoOfChanges++;
+            return propertyList.WithProperties(
+                    propertyList.Properties.Remove(property));
+        }
+
+        private void CheckIfMemberAppAreasAreTheSame(string memberAppArea)
+        {
+            switch (_pageMembersAppAreaState)
+            {
+                case PageMembersAppAreaState.NotChecked:
+                    _pageMembersAppArea = memberAppArea;
+                    _pageMembersAppAreaState = PageMembersAppAreaState.Equal;
+                    break;
+                case PageMembersAppAreaState.Equal:
+                    var equal =
+                        ((memberAppArea == null) && (_pageMembersAppArea == null)) ||
+                        ((memberAppArea != null) && (_pageMembersAppArea != null) && (memberAppArea.Equals(_pageMembersAppArea, StringComparison.CurrentCultureIgnoreCase)));
+                    if (!equal)
+                    {
+                        _pageMembersAppArea = null;
+                        _pageMembersAppAreaState = PageMembersAppAreaState.Different;
+                    }    
+                    break;
+            }
+        }
+
+        protected string GetApplicationAreaValue(SyntaxNode node)
+        {
+            PropertySyntax appAreaProperty = node.GetProperty("ApplicationArea");
+            if (appAreaProperty != null)
+                return ALSyntaxHelper.DecodeName(appAreaProperty.Value?.ToString());
+            return null;
+        }
+
+        protected PropertySyntax CreateApplicationAreaProperty(SyntaxNode node, string value)
+        {
+            //calculate indent
+            int indentLength = 4;
+            string indent;
+            SyntaxTriviaList leadingTrivia = node.GetLeadingTrivia();
+            if (leadingTrivia != null)
+            {
+                indent = leadingTrivia.ToString();
+                int newLinePos = indent.LastIndexOf("/n");
+                if (newLinePos >= 0)
+                    indent = indent.Substring(newLinePos + 1);
+                indentLength += indent.Length;
+            }
+            indent = "".PadLeft(indentLength);
+
+            SyntaxTriviaList leadingTriviaList = SyntaxFactory.ParseLeadingTrivia(indent, 0);
+            SyntaxTriviaList trailingTriviaList = SyntaxFactory.ParseTrailingTrivia("\r\n", 0);
+
+            SeparatedSyntaxList<IdentifierNameSyntax> values = new SeparatedSyntaxList<IdentifierNameSyntax>();
+            values = values.Add(SyntaxFactory.IdentifierName(value));
+
+            //try to convert from string to avoid issues with enum ids changed between AL compiler versions
+            PropertyKind propertyKind;
+            try
+            {
+                propertyKind = (PropertyKind)Enum.Parse(typeof(PropertyKind), "ApplicationArea", true);
+            }
+            catch (Exception)
+            {
+                propertyKind = PropertyKind.ApplicationArea;
+            }
+
+            return SyntaxFactory.Property(propertyKind, SyntaxFactory.CommaSeparatedPropertyValue(values))
+                .WithLeadingTrivia(leadingTriviaList)
+                .WithTrailingTrivia(trailingTriviaList);
+        }
+
+
+    }
+}

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/CodeTransformations/ToolTipSyntaxRewriter.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/CodeTransformations/ToolTipSyntaxRewriter.cs
@@ -96,7 +96,8 @@ namespace AnZwDev.ALTools.CodeTransformations
                 //get caption from control name
                 else if (String.IsNullOrWhiteSpace(caption))
                 {
-                    caption = node.GetNameStringValue().RemovePrefixSuffix(this.Project.MandatoryPrefixes, this.Project.MandatorySuffixes, this.Project.MandatoryAffixes);
+                    caption = node.GetNameStringValue().RemovePrefixSuffix(
+                        this.Project.MandatoryPrefixes, this.Project.MandatorySuffixes, this.Project.MandatoryAffixes, this.Project.AdditionalMandatoryAffixesPatterns);
                     comment = null;
                 }
 

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/DuplicateCodeSearch/DCDuplicateCodeAnalyzer.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/DuplicateCodeSearch/DCDuplicateCodeAnalyzer.cs
@@ -1,4 +1,5 @@
 ﻿using AnZwDev.ALTools.ALSymbols;
+using AnZwDev.ALTools.ALSymbols.Internal;
 using AnZwDev.ALTools.Workspace;
 using System;
 using System.Collections.Generic;
@@ -11,17 +12,19 @@ namespace AnZwDev.ALTools.DuplicateCodeSearch
     {
 
         public int MinNoOfStatements { get; }
+        public ConvertedObsoleteState SkipObsoleteCodeLevel { get; }
 
-        public DCDuplicateCodeAnalyzer(int minNoOfStatements)
+        public DCDuplicateCodeAnalyzer(int minNoOfStatements, ConvertedObsoleteState skipObsoleteCodeLevel)
         {
             if (minNoOfStatements < 2)
                 minNoOfStatements = 2;
             this.MinNoOfStatements = minNoOfStatements;
+            this.SkipObsoleteCodeLevel = skipObsoleteCodeLevel;
         }
 
         public List<DCDuplicate> FindDuplicates(ALWorkspace workspace, string path)
         {
-            DCStatementKeyDictionaryBuilder statementsBuilder = new DCStatementKeyDictionaryBuilder();
+            DCStatementKeyDictionaryBuilder statementsBuilder = new DCStatementKeyDictionaryBuilder(SkipObsoleteCodeLevel);
 
             ALProject singleProject = null;
             if (!String.IsNullOrWhiteSpace(path))

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/DuplicateCodeSearch/DCStatementKeyDictionaryBuilder.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/DuplicateCodeSearch/DCStatementKeyDictionaryBuilder.cs
@@ -14,10 +14,12 @@ namespace AnZwDev.ALTools.DuplicateCodeSearch
     {
 
         protected string _sourceFilePath;
+        public ConvertedObsoleteState SkipObsoleteCodeLevel { get; }
         public DCStatementKeyDictionary StatementsDictionary { get; } = new DCStatementKeyDictionary();
 
-        public DCStatementKeyDictionaryBuilder()
+        public DCStatementKeyDictionaryBuilder(ConvertedObsoleteState skipObsoleteCodeLevel)
         {
+            SkipObsoleteCodeLevel = skipObsoleteCodeLevel;
         }
 
         public void VisitProjectFolder(string filePath)
@@ -48,7 +50,7 @@ namespace AnZwDev.ALTools.DuplicateCodeSearch
 
         protected void VisitMethodOrTriggerDeclaration(MethodOrTriggerDeclarationSyntax node, DCCodeBlockType codeBlockType)
         {
-            if (node.Body != null)
+            if ((ValidNode(node)) && (node.Body != null))
             {
                 DCStatementsBlock statementsBlock = new DCStatementsBlock(_sourceFilePath, codeBlockType);
                 AppendMethodOrTriggerHeader(node, statementsBlock);
@@ -309,6 +311,13 @@ namespace AnZwDev.ALTools.DuplicateCodeSearch
             DCStatementInstance statementInstance = new DCStatementInstance(statementsBlock, key, range, statementsBlock.Statements.Count);
             statementsBlock.Statements.Add(statementInstance);
             key.StatementInstances.Add(statementInstance);
+        }
+
+        private bool ValidNode(SyntaxNode node)
+        {
+            return
+                (SkipObsoleteCodeLevel == ConvertedObsoleteState.None) ||
+                (!node.IsInsideObsoleteSyntaxTreeBranch(SkipObsoleteCodeLevel));
         }
 
     }

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/Extensions/CharExtensions.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/Extensions/CharExtensions.cs
@@ -12,5 +12,15 @@ namespace AnZwDev.ALTools.Extensions
             return (character == '\n') || (character == '\r');
         }
 
+        public static bool IsPatternEqualIgnoreCase(this char character, char patternCharacter)
+        {
+            return (patternCharacter == '?') || (Char.ToUpper(character) == Char.ToUpper(patternCharacter));
+        }
+
+        public static bool IsPatternEqual(this char character, char patternCharacter)
+        {
+            return (patternCharacter == '?') || (character == patternCharacter);
+        }
+
     }
 }

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/Extensions/StringExtensions.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/Extensions/StringExtensions.cs
@@ -339,5 +339,12 @@ namespace AnZwDev.ALTools.Extensions
             return ((value != null) && (value.Equals("true", StringComparison.CurrentCultureIgnoreCase)));
         }
 
+        public static T ToEnum<T>(this string value) where T : struct
+        {
+            if (Enum.TryParse<T>(value, true, out T result))
+                return result;
+            return default(T);
+        }
+
     }
 }

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/Extensions/SyntaxNodeExtensions.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/Extensions/SyntaxNodeExtensions.cs
@@ -7,7 +7,6 @@ using System;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Text;
-using Microsoft.Dynamics.Nav.EditorServices.Protocol;
 
 namespace AnZwDev.ALTools.Extensions
 {

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/Extensions/SyntaxTriviaListExtensions.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/Extensions/SyntaxTriviaListExtensions.cs
@@ -97,6 +97,19 @@ namespace AnZwDev.ALTools.Extensions
             return true;
         }
 
+        public static bool HasNewLine(this IEnumerable<SyntaxTrivia> triviaList)
+        {
+            if (triviaList == null)
+                return false;
+            foreach (SyntaxTrivia trivia in triviaList)
+            {
+                if (trivia.Kind.ConvertToLocalType() == ConvertedSyntaxKind.EndOfLineTrivia)
+                    return true;
+            }
+            return false;
+        }
+
+
         public static bool ContainsDirectives(this IEnumerable<SyntaxTrivia> triviaList)
         {
             if (triviaList == null)

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/Navigation/WarningDirectivesReferencesProvider.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/Navigation/WarningDirectivesReferencesProvider.cs
@@ -11,6 +11,8 @@ using System.Text;
 
 namespace AnZwDev.ALTools.Navigation
 {
+
+#if BC
     public class WarningDirectivesReferencesProvider : ReferencesProvider
     {
 
@@ -67,4 +69,5 @@ namespace AnZwDev.ALTools.Navigation
         }
 
     }
+#endif
 }

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/Shared.AnZwDev.ALTools.projitems
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/Shared.AnZwDev.ALTools.projitems
@@ -167,6 +167,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)CodeTransformations\AppAreaSyntaxRewriter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CodeTransformations\BasePageWithSourceSyntaxRewriter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CodeTransformations\BaseToolTipsSyntaxRewriter.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)CodeTransformations\DirectiveTriviaMergedList.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CodeTransformations\FixTextOverflowAssignmentSyntaxRewriter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CodeTransformations\RefreshToolTipsSyntaxRewriter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CodeTransformations\RemoveBeginEndSyntaxRewriter.cs" />

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/Shared.AnZwDev.ALTools.projitems
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/Shared.AnZwDev.ALTools.projitems
@@ -170,6 +170,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)CodeTransformations\BaseToolTipsSyntaxRewriter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CodeTransformations\DirectiveTriviaMergedList.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CodeTransformations\FixTextOverflowAssignmentSyntaxRewriter.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)CodeTransformations\MakeFlowFieldsReadOnlySyntaxRewriter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CodeTransformations\RefreshToolTipsSyntaxRewriter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CodeTransformations\RemoveBeginEndSyntaxRewriter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CodeTransformations\ConvertObjectIdsToNamesSyntaxRewriter.cs" />
@@ -267,6 +268,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)WorkspaceCommands\FixKeywordsCaseWorkspaceCommand.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)WorkspaceCommands\FormatDocumentWorkspaceCommand.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)WorkspaceCommands\LockRemovedFieldsCaptionsWorkspaceCommand.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)WorkspaceCommands\MakeFlowFieldsReadOnlyWorkspaceCommand.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)WorkspaceCommands\RefreshToolTipsWorkspaceCommand.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)WorkspaceCommands\RemoveBeginEndWorkspaceCommand.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)WorkspaceCommands\RemoveEmptyLinesWorkspaceCommand.cs" />

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/Shared.AnZwDev.ALTools.projitems
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/Shared.AnZwDev.ALTools.projitems
@@ -165,12 +165,14 @@
     <Compile Include="$(MSBuildThisFileDirectory)CodeTransformations\ALCaptionsSyntaxRewriter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CodeTransformations\ALSemanticModelSyntaxRewriter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CodeTransformations\ALSyntaxRewriter.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)CodeTransformations\AppAreaMode.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CodeTransformations\AppAreaSyntaxRewriter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CodeTransformations\BasePageWithSourceSyntaxRewriter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CodeTransformations\BaseToolTipsSyntaxRewriter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CodeTransformations\DirectiveTriviaMergedList.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CodeTransformations\FixTextOverflowAssignmentSyntaxRewriter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CodeTransformations\MakeFlowFieldsReadOnlySyntaxRewriter.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)CodeTransformations\RemoveRedundandAppAreasSyntaxRewriter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CodeTransformations\RefreshToolTipsSyntaxRewriter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CodeTransformations\RemoveBeginEndSyntaxRewriter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CodeTransformations\ConvertObjectIdsToNamesSyntaxRewriter.cs" />
@@ -275,6 +277,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)WorkspaceCommands\RemoveEmptySectionsWorkspaceCommand.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)WorkspaceCommands\RemoveEmptyTriggersWorkspaceCommand.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)WorkspaceCommands\RemoveEventPublishersWorkspaceCommand.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)WorkspaceCommands\RemoveRedundantAppAreasWorkspaceCommand.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)WorkspaceCommands\RemoveStrSubstNoFromErrorWorkspaceCommand.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)WorkspaceCommands\RemoveUnusedVariablesWorkspaceCommand.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)WorkspaceCommands\RemoveVariableWorkspaceCommand.cs" />

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/Shared.AnZwDev.ALTools.projitems
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/Shared.AnZwDev.ALTools.projitems
@@ -132,6 +132,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)ALSymbols\Internal\ConvertedControlKind.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ALSymbols\Internal\ConvertedMethodKind.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ALSymbols\Internal\ConvertedNavTypeKind.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)ALSymbols\Internal\ConvertedObsoleteState.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ALSymbols\Internal\ConvertedOperationKind.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ALSymbols\Internal\ConvertedSymbolKind.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ALSymbols\Internal\ConvertedSyntaxKind.cs" />

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/Workspace/ALProject.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/Workspace/ALProject.cs
@@ -40,7 +40,7 @@ namespace AnZwDev.ALTools.Workspace
         public List<string> MandatoryPrefixes { get; set; }
         public List<string> MandatorySuffixes { get; set; }
         public List<string> MandatoryAffixes { get; set; }
-
+        public List<string> AdditionalMandatoryAffixesPatterns { get; set; }
         public ALProjectDependenciesCollection Dependencies { get; }
         
         /// <summary>
@@ -69,6 +69,8 @@ namespace AnZwDev.ALTools.Workspace
                 this.PackageCachePath = projectSource.packageCachePath;
             else
                 this.PackageCachePath = ".alpackages";
+            this.CodeAnalyzers = projectSource?.codeAnalyzers;
+            this.AdditionalMandatoryAffixesPatterns = projectSource?.additionalMandatoryAffixesPatterns;
             this.MandatoryPrefixes = null;
             this.MandatorySuffixes = null;
             this.Workspace = workspace;
@@ -316,6 +318,7 @@ namespace AnZwDev.ALTools.Workspace
                 this.ResolveDependencies();
             }
             this.CodeAnalyzers = projectSource.codeAnalyzers;
+            this.AdditionalMandatoryAffixesPatterns = projectSource.additionalMandatoryAffixesPatterns;
         }
 
         public void OnDocumentOpen(string path)

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/Workspace/ALProjectSource.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/Workspace/ALProjectSource.cs
@@ -9,16 +9,19 @@ namespace AnZwDev.ALTools.Workspace
         public string folderPath { get; set; }
         public string packageCachePath { get; set; }
         public List<string> codeAnalyzers { get; set; }
+        public List<string> additionalMandatoryAffixesPatterns { get; set; }
+
 
         public ALProjectSource()
         {
         }
 
-        public ALProjectSource(string newFolderPath, string newPackageCachePath, List<string> codeAnalyzers)
+        public ALProjectSource(string newFolderPath, string newPackageCachePath, List<string> codeAnalyzers, List<string> additionalAffixesPatterns)
         {
             this.folderPath = newFolderPath;
             this.packageCachePath = newPackageCachePath;
             this.codeAnalyzers = codeAnalyzers;
+            this.additionalMandatoryAffixesPatterns = additionalAffixesPatterns;
         }
     }
 }

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/Workspace/SymbolsInformation/PageInformation.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/Workspace/SymbolsInformation/PageInformation.cs
@@ -9,6 +9,9 @@ namespace AnZwDev.ALTools.Workspace.SymbolsInformation
     public class PageInformation : TableBasedSymbolWithIdInformation
     {
 
+        [JsonProperty("applicationArea")]
+        public string ApplicationArea { get; set; }
+
         public PageInformation()
         {
         }
@@ -19,6 +22,7 @@ namespace AnZwDev.ALTools.Workspace.SymbolsInformation
             {
                 this.Caption = page.Properties.GetValue("Caption");
                 this.Source = page.Properties.GetValue("SourceTable");
+                this.ApplicationArea = page.Properties.GetValue("ApplicationArea");
             }
         }
 

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/Workspace/SymbolsInformation/TableFieldInformaton.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/Workspace/SymbolsInformation/TableFieldInformaton.cs
@@ -60,7 +60,8 @@ namespace AnZwDev.ALTools.Workspace.SymbolsInformation
             {
                 string caption = this.Name;
                 if (project != null)
-                    caption = caption.RemovePrefixSuffix(project.MandatoryPrefixes, project.MandatorySuffixes, project.MandatoryAffixes);
+                    caption = caption.RemovePrefixSuffix(
+                        project.MandatoryPrefixes, project.MandatorySuffixes, project.MandatoryAffixes, project.AdditionalMandatoryAffixesPatterns);
                 this.Caption = caption;
                 this.CaptionLabel.SetValue(this.Caption);
             }

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/WorkspaceCommands/AddAppAreasWorkspaceCommand.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/WorkspaceCommands/AddAppAreasWorkspaceCommand.cs
@@ -1,5 +1,6 @@
 ﻿using AnZwDev.ALTools.ALSymbols;
 using AnZwDev.ALTools.CodeTransformations;
+using AnZwDev.ALTools.Extensions;
 using Microsoft.Dynamics.Nav.CodeAnalysis;
 using System;
 using System.Collections.Generic;
@@ -11,6 +12,7 @@ namespace AnZwDev.ALTools.WorkspaceCommands
     {
 
         public static string AppAreaParameterName = "appArea";
+        public static string AppAreaModeParameterName = "appAreaMode";
 
         public AddAppAreasWorkspaceCommand(ALDevToolsServer alDevToolsServer) : base(alDevToolsServer, "addAppAreas")
         {
@@ -23,6 +25,8 @@ namespace AnZwDev.ALTools.WorkspaceCommands
                 this.SyntaxRewriter.ApplicationAreaName = parameters[AppAreaParameterName];
             if (String.IsNullOrWhiteSpace(this.SyntaxRewriter.ApplicationAreaName))
                 this.SyntaxRewriter.ApplicationAreaName = "All";
+            if (parameters.ContainsKey(AppAreaModeParameterName))
+                this.SyntaxRewriter.ApplicationAreaMode = parameters[AppAreaModeParameterName].ToEnum<AppAreaMode>();
         }
 
     }

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/WorkspaceCommands/MakeFlowFieldsReadOnlyWorkspaceCommand.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/WorkspaceCommands/MakeFlowFieldsReadOnlyWorkspaceCommand.cs
@@ -1,0 +1,17 @@
+﻿using AnZwDev.ALTools.CodeTransformations;
+using AnZwDev.ALTools.Extensions;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace AnZwDev.ALTools.WorkspaceCommands
+{
+    public class MakeFlowFieldsReadOnlyWorkspaceCommand : SyntaxRewriterWorkspaceCommand<MakeFlowFieldsReadOnlySyntaxRewriter>
+    {
+
+        public MakeFlowFieldsReadOnlyWorkspaceCommand(ALDevToolsServer alDevToolsServer) : base(alDevToolsServer, "makeFlowFieldsReadOnly")
+        {
+        }
+
+    }
+}

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/WorkspaceCommands/RemoveRedundantAppAreasWorkspaceCommand.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/WorkspaceCommands/RemoveRedundantAppAreasWorkspaceCommand.cs
@@ -1,0 +1,15 @@
+﻿using AnZwDev.ALTools.CodeTransformations;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace AnZwDev.ALTools.WorkspaceCommands
+{
+    public class RemoveRedundantAppAreasWorkspaceCommand : SyntaxRewriterWorkspaceCommand<RemoveRedundandAppAreasSyntaxRewriter>
+    {
+
+        public RemoveRedundantAppAreasWorkspaceCommand(ALDevToolsServer alDevToolsServer) : base(alDevToolsServer, "removeRedundantAppAreas")
+        {
+        }
+    }
+}

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/WorkspaceCommands/SemanticModelWorkspaceCommand.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/WorkspaceCommands/SemanticModelWorkspaceCommand.cs
@@ -69,11 +69,16 @@ namespace AnZwDev.ALTools.WorkspaceCommands
             string projectFile = Path.Combine(projectPath, "app.json");
             ProjectManifest manifest = ProjectManifest.ReadFromString(projectFile, FileUtils.SafeReadAllText(projectFile), diagnostics);
 
+            //initialize compilation options
+            var compilationOptions = new CompilationOptions(
+                target: manifest.AppManifest.Target,
+                compilerFeatures: manifest.AppManifest.CompilerFeatures);
+
             //create compilation
             Compilation compilation = Compilation.Create("MyCompilation", manifest.AppManifest.AppPublisher,
                 manifest.AppManifest.AppVersion, manifest.AppManifest.AppId,
                 null, syntaxTrees,
-                new CompilationOptions());
+                compilationOptions);
 
             LocalCacheSymbolReferenceLoader referenceLoader =
                 this.SafeCreateLocalCacheSymbolReferenceLoader(Path.Combine(projectPath, alPackagesPath));

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/WorkspaceCommands/WorkspaceCommandsManager.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/WorkspaceCommands/WorkspaceCommandsManager.cs
@@ -39,6 +39,7 @@ namespace AnZwDev.ALTools.WorkspaceCommands
             this.RegisterCommand(new AddFieldCaptionsWorkspaceCommand(this.ALDevToolsServer));
             this.RegisterCommand(new LockRemovedFieldsCaptionsWorkspaceCommand(this.ALDevToolsServer));
             this.RegisterCommand(new AddObjectCaptionsWorkspaceCommand(this.ALDevToolsServer));
+            this.RegisterCommand(new MakeFlowFieldsReadOnlyWorkspaceCommand(this.ALDevToolsServer));
 
             this.RegisterCommand(new FixKeywordsCaseWorkspaceCommand(this.ALDevToolsServer));
 

--- a/AZALDevToolsServer/Shared.AnZwDev.ALTools/WorkspaceCommands/WorkspaceCommandsManager.cs
+++ b/AZALDevToolsServer/Shared.AnZwDev.ALTools/WorkspaceCommands/WorkspaceCommandsManager.cs
@@ -56,6 +56,7 @@ namespace AnZwDev.ALTools.WorkspaceCommands
             this.RegisterCommand(new AddParenthesesWorkspaceCommand(this.ALDevToolsServer));
             this.RegisterCommand(new RemoveStrSubstNoFromErrorWorkspaceCommand(this.ALDevToolsServer));
             this.RegisterCommand(new RemoveEventPublishersWorkspaceCommand(this.ALDevToolsServer));
+            this.RegisterCommand(new RemoveRedundantAppAreasWorkspaceCommand(this.ALDevToolsServer));
 #endif
 
             this.RegisterCommand(new RemoveVariableWorkspaceCommand(this.ALDevToolsServer));


### PR DESCRIPTION
 - Suggestion 387 - BC21 - Field ApplicationArea defaults to page value 
 - Issue 389 - "Add Missing Parentheses": Skip variables with the same name as a record function. 
 - Issue 393 - Make FlowFields read-only, remove DataClassification from FlowFields and FlowFilters
   - new editor and project "Make FlowFields Read-Only..." commands
   - new "MakeFlowFieldsReadOnly" option for Code Clean-up
   - DataClassification command removes property from FlowField and FlowFilter table fields
 - Issue 394 - alOutline.codeCleanupActions: tooltips appear to be "off-by-one"
 - Issue 396 - Account for affixes in the variable name-type completion provider(s)
   - "_" character detection in affixes bugfix
   - new "alOutline.additionalMandatoryAffixesPatterns" setting - affixes patterns where '?' character can be used as "any character"
 - Issue 397 - RemoveEmptyTriggers conflicts with regions 
 - Issue 398 - Add semicolon to end of the new completion provider 
   - ";" is added to variables declaration suggestions as it is always required
   - ";" is not added to parameters and return variable declaration suggestions
 - Issue 399 - ignore duplicates if area is obsolete while using "Find Duplicates" 